### PR TITLE
Complete remaining banking features

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Windows (PowerShell):
 * `.\gradlew.bat run --args="deposit ACC-0001 50.00"` (use the account id printed by `create-account`)
 * `.\gradlew.bat run --args="withdraw ACC-0001 25.00"` (use the account id printed by `create-account`)
 * `.\gradlew.bat run --args="check-balance ACC-0001"` (use the account id printed by `create-account`)
+* `.\gradlew.bat run --args="transaction-history ACC-0001"`
+* `.\gradlew.bat run --args="transfer ACC-0001 ACC-0002 10.00"`
+* `.\gradlew.bat run --args="close-account ACC-0001"`
+* `.\gradlew.bat run --args="collect-fee admin admin123 ACC-0001 5.00"`
+* `.\gradlew.bat run --args="add-interest admin admin123 ACC-0001 3.00"`
 * `.\gradlew.bat run --args="clear-data"` (wipes the local database and re-seeds the demo customer `CUST-001`)
 
 macOS/Linux:
@@ -46,17 +51,30 @@ macOS/Linux:
 * `./gradlew run --args="deposit ACC-0001 50.00"`
 * `./gradlew run --args="withdraw ACC-0001 25.00"`
 * `./gradlew run --args="check-balance ACC-0001"`
+* `./gradlew run --args="transaction-history ACC-0001"`
+* `./gradlew run --args="transfer ACC-0001 ACC-0002 10.00"`
+* `./gradlew run --args="close-account ACC-0001"`
+* `./gradlew run --args="collect-fee admin admin123 ACC-0001 5.00"`
+* `./gradlew run --args="add-interest admin admin123 ACC-0001 3.00"`
 * `./gradlew run --args="clear-data"`
 
-**Persistence:** Account data is stored in a local SQLite file named `bank.db` in the working directory (created on first run). Separate `gradlew run` invocations share this file, so balances survive between commands. To use a different path: add `-Dbank.db.file=/absolute/path/to/bank.db` to the `gradlew` command (before `run`).
+**Persistence:** Account data is stored in a local SQLite file named `bank.db` in the working directory (created on first run). Separate `gradlew run` invocations share this file, so balances and transaction history survive between commands. To use a different path: add `-Dbank.db.file=/absolute/path/to/bank.db` to the Java process before `run` (for example through `JAVA_TOOL_OPTIONS`).
 
-Implemented in this iteration:
+**Seeded admin credentials:** username `admin`, password `admin123`
 
+Implemented features:
+
+* User story **#1**: deposit into an existing account
+* User story **#2**: withdraw from an account
+* User story **#3**: check an account balance
+* User story **#4**: view transaction history for an account
 * User story **#5**: create an additional account for an existing customer
-* User story **#3**: check an account balance via `check-balance <accountId>`
-* Validation (unknown customer, invalid opening deposit, missing account) and unit tests
-* Command-line commands: `create-account <customerId> <CHECKING|SAVINGS> <openingDeposit>`, `deposit <accountId> <amount>`, `withdraw <accountId> <amount>`, `check-balance <accountId>`, `clear-data`
-* SQLite-backed storage so CLI runs persist state to disk
+* User story **#6**: close an existing account
+* User story **#7**: transfer money from one account to another
+* User story **#8**: bank administrator can collect fees from existing accounts
+* User story **#9**: bank administrator can add an interest payment to an existing account
+* Command-line commands: `create-account`, `deposit`, `withdraw`, `check-balance`, `transaction-history`, `close-account`, `transfer`, `collect-fee`, `add-interest`, `clear-data`
+* SQLite-backed storage persists customers, accounts, transaction history, and admin credentials between CLI runs
 
 ---
 

--- a/src/main/java/edu/washu/bank/App.java
+++ b/src/main/java/edu/washu/bank/App.java
@@ -3,13 +3,14 @@ package edu.washu.bank;
 import edu.washu.bank.core.Bank;
 import edu.washu.bank.model.Account;
 import edu.washu.bank.model.AccountType;
+import edu.washu.bank.model.Transaction;
 import edu.washu.bank.persistence.SqliteBankStore;
 import edu.washu.bank.service.AccountService;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.nio.file.Path;
 import java.sql.SQLException;
-
 
 public class App {
     public static void main(String[] args) {
@@ -41,6 +42,11 @@ public class App {
             return;
         }
 
+        if ("transaction-history".equalsIgnoreCase(args[0])) {
+            runTransactionHistory(accountService, args);
+            return;
+        }
+
         if ("deposit".equalsIgnoreCase(args[0])) {
             runDeposit(store, bank, accountService, args);
             return;
@@ -51,6 +57,26 @@ public class App {
             return;
         }
 
+        if ("close-account".equalsIgnoreCase(args[0])) {
+            runCloseAccount(store, bank, accountService, args);
+            return;
+        }
+
+        if ("transfer".equalsIgnoreCase(args[0])) {
+            runTransfer(store, bank, accountService, args);
+            return;
+        }
+
+        if ("collect-fee".equalsIgnoreCase(args[0])) {
+            runCollectFee(store, bank, accountService, args);
+            return;
+        }
+
+        if ("add-interest".equalsIgnoreCase(args[0])) {
+            runAddInterest(store, bank, accountService, args);
+            return;
+        }
+
         if ("clear-data".equalsIgnoreCase(args[0])) {
             runClearData(store, dbPath);
             return;
@@ -58,42 +84,6 @@ public class App {
 
         System.out.println("Unknown command: " + args[0]);
         printUsage(dbPath);
-    }
-
-    private static void runWithdraw(
-            SqliteBankStore store,
-            Bank bank,
-            AccountService accountService,
-            String[] args
-    ) {
-        if (args.length != 3) {
-            System.out.println("Invalid arguments for withdraw.");
-            printUsage(SqliteBankStore.resolveDatabasePath());
-            return;
-        }
-
-        String accountId = args[1];
-
-        BigDecimal amount;
-        try {
-            amount = new BigDecimal(args[2]);
-        } catch (NumberFormatException ex) {
-            System.out.println("Invalid withdraw amount: " + args[2]);
-            return;
-        }
-
-        try {
-            accountService.withdraw(accountId, amount);
-            store.saveFullState(bank);
-            BigDecimal newBalance = accountService.getBalance(accountId);
-            System.out.println(
-                    "Withdrew " + amount + " from account " + accountId + ". New balance: " + newBalance
-            );
-        } catch (RuntimeException ex) {
-            System.out.println(ex.getMessage());
-        } catch (SQLException ex) {
-            System.err.println("Database error: " + ex.getMessage());
-        }
     }
 
     private static void runCreateAccount(
@@ -158,6 +148,39 @@ public class App {
         }
     }
 
+    private static void runTransactionHistory(AccountService accountService, String[] args) {
+        if (args.length != 2) {
+            System.out.println("Invalid arguments for transaction-history.");
+            printUsage(SqliteBankStore.resolveDatabasePath());
+            return;
+        }
+
+        String accountId = args[1];
+        try {
+            List<Transaction> history = accountService.getTransactionHistory(accountId);
+            System.out.println("Transaction history for account " + accountId + ":");
+            if (history.isEmpty()) {
+                System.out.println("  No transactions found.");
+                return;
+            }
+            for (Transaction transaction : history) {
+                String related = transaction.getRelatedAccountId() == null
+                        ? ""
+                        : " | related account: " + transaction.getRelatedAccountId();
+                System.out.println(
+                        "  " + transaction.getId()
+                                + " | " + transaction.getType()
+                                + " | amount: " + transaction.getAmount()
+                                + " | balance after: " + transaction.getBalanceAfter()
+                                + related
+                                + " | " + transaction.getDescription()
+                );
+            }
+        } catch (RuntimeException ex) {
+            System.out.println(ex.getMessage());
+        }
+    }
+
     private static void runDeposit(
             SqliteBankStore store,
             Bank bank,
@@ -195,6 +218,170 @@ public class App {
         }
     }
 
+    private static void runWithdraw(
+            SqliteBankStore store,
+            Bank bank,
+            AccountService accountService,
+            String[] args
+    ) {
+        if (args.length != 3) {
+            System.out.println("Invalid arguments for withdraw.");
+            printUsage(SqliteBankStore.resolveDatabasePath());
+            return;
+        }
+
+        String accountId = args[1];
+
+        BigDecimal amount;
+        try {
+            amount = new BigDecimal(args[2]);
+        } catch (NumberFormatException ex) {
+            System.out.println("Invalid withdraw amount: " + args[2]);
+            return;
+        }
+
+        try {
+            Account updatedAccount = accountService.withdraw(accountId, amount);
+            store.saveFullState(bank);
+            System.out.println(
+                    "Withdrew " + amount
+                            + " from account " + updatedAccount.getId()
+                            + ". New balance: " + updatedAccount.getBalance()
+            );
+        } catch (RuntimeException ex) {
+            System.out.println(ex.getMessage());
+        } catch (SQLException ex) {
+            System.err.println("Database error: " + ex.getMessage());
+        }
+    }
+
+    private static void runCloseAccount(
+            SqliteBankStore store,
+            Bank bank,
+            AccountService accountService,
+            String[] args
+    ) {
+        if (args.length != 2) {
+            System.out.println("Invalid arguments for close-account.");
+            printUsage(SqliteBankStore.resolveDatabasePath());
+            return;
+        }
+
+        String accountId = args[1];
+        try {
+            BigDecimal cashOutAmount = accountService.closeAccount(accountId);
+            store.saveFullState(bank);
+            System.out.println(
+                    "Closed account " + accountId + ". Cash-out amount: " + cashOutAmount
+            );
+        } catch (RuntimeException ex) {
+            System.out.println(ex.getMessage());
+        } catch (SQLException ex) {
+            System.err.println("Database error: " + ex.getMessage());
+        }
+    }
+
+    private static void runTransfer(
+            SqliteBankStore store,
+            Bank bank,
+            AccountService accountService,
+            String[] args
+    ) {
+        if (args.length != 4) {
+            System.out.println("Invalid arguments for transfer.");
+            printUsage(SqliteBankStore.resolveDatabasePath());
+            return;
+        }
+
+        BigDecimal amount;
+        try {
+            amount = new BigDecimal(args[3]);
+        } catch (NumberFormatException ex) {
+            System.out.println("Invalid transfer amount: " + args[3]);
+            return;
+        }
+
+        try {
+            accountService.transfer(args[1], args[2], amount);
+            store.saveFullState(bank);
+            System.out.println(
+                    "Transferred " + amount + " from " + args[1] + " to " + args[2] + "."
+            );
+        } catch (RuntimeException ex) {
+            System.out.println(ex.getMessage());
+        } catch (SQLException ex) {
+            System.err.println("Database error: " + ex.getMessage());
+        }
+    }
+
+    private static void runCollectFee(
+            SqliteBankStore store,
+            Bank bank,
+            AccountService accountService,
+            String[] args
+    ) {
+        if (args.length != 5) {
+            System.out.println("Invalid arguments for collect-fee.");
+            printUsage(SqliteBankStore.resolveDatabasePath());
+            return;
+        }
+
+        BigDecimal amount;
+        try {
+            amount = new BigDecimal(args[4]);
+        } catch (NumberFormatException ex) {
+            System.out.println("Invalid fee amount: " + args[4]);
+            return;
+        }
+
+        try {
+            Account updatedAccount = accountService.collectFee(args[1], args[2], args[3], amount);
+            store.saveFullState(bank);
+            System.out.println(
+                    "Collected fee of " + amount + " from account " + updatedAccount.getId()
+                            + ". New balance: " + updatedAccount.getBalance()
+            );
+        } catch (RuntimeException ex) {
+            System.out.println(ex.getMessage());
+        } catch (SQLException ex) {
+            System.err.println("Database error: " + ex.getMessage());
+        }
+    }
+
+    private static void runAddInterest(
+            SqliteBankStore store,
+            Bank bank,
+            AccountService accountService,
+            String[] args
+    ) {
+        if (args.length != 5) {
+            System.out.println("Invalid arguments for add-interest.");
+            printUsage(SqliteBankStore.resolveDatabasePath());
+            return;
+        }
+
+        BigDecimal amount;
+        try {
+            amount = new BigDecimal(args[4]);
+        } catch (NumberFormatException ex) {
+            System.out.println("Invalid interest amount: " + args[4]);
+            return;
+        }
+
+        try {
+            Account updatedAccount = accountService.addInterest(args[1], args[2], args[3], amount);
+            store.saveFullState(bank);
+            System.out.println(
+                    "Added interest of " + amount + " to account " + updatedAccount.getId()
+                            + ". New balance: " + updatedAccount.getBalance()
+            );
+        } catch (RuntimeException ex) {
+            System.out.println(ex.getMessage());
+        } catch (SQLException ex) {
+            System.err.println("Database error: " + ex.getMessage());
+        }
+    }
+
     private static void runClearData(SqliteBankStore store, Path dbPath) {
         try {
             store.clearAllAndReseed();
@@ -209,16 +396,31 @@ public class App {
         System.out.println("Bank CLI (SQLite: " + dbPath.toAbsolutePath().normalize() + ")");
         System.out.println("Override path: -Dbank.db.file=/path/to/bank.db");
         System.out.println("Seeded customer for demo: CUST-001");
+        System.out.println(
+                "Seeded admin for demo: "
+                        + SqliteBankStore.SEEDED_ADMIN_USERNAME
+                        + " / "
+                        + SqliteBankStore.SEEDED_ADMIN_PASSWORD
+        );
         System.out.println("Usage:");
         System.out.println("  create-account <customerId> <CHECKING|SAVINGS> <openingDeposit>");
+        System.out.println("  transaction-history <accountId>");
         System.out.println("  deposit <accountId> <amount>");
         System.out.println("  withdraw <accountId> <amount>");
+        System.out.println("  close-account <accountId>");
+        System.out.println("  transfer <fromAccountId> <toAccountId> <amount>");
+        System.out.println("  collect-fee <adminUsername> <adminPassword> <accountId> <amount>");
+        System.out.println("  add-interest <adminUsername> <adminPassword> <accountId> <amount>");
         System.out.println("  check-balance <accountId>");
         System.out.println("  clear-data");
         System.out.println("Examples:");
         System.out.println("  create-account CUST-001 CHECKING 100.00");
         System.out.println("  check-balance ACC-0001");
         System.out.println("  deposit ACC-0001 50.00");
-        System.out.println("  withdraw ACC-001 25.00");
+        System.out.println("  withdraw ACC-0001 25.00");
+        System.out.println("  transaction-history ACC-0001");
+        System.out.println("  transfer ACC-0001 ACC-0002 10.00");
+        System.out.println("  collect-fee admin admin123 ACC-0001 5.00");
+        System.out.println("  add-interest admin admin123 ACC-0001 3.00");
     }
 }

--- a/src/main/java/edu/washu/bank/core/Bank.java
+++ b/src/main/java/edu/washu/bank/core/Bank.java
@@ -1,18 +1,24 @@
 package edu.washu.bank.core;
 
 import edu.washu.bank.model.Account;
+import edu.washu.bank.model.AdminUser;
 import edu.washu.bank.model.Customer;
+import edu.washu.bank.model.Transaction;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class Bank {
     private final Map<String, Customer> customers = new LinkedHashMap<>();
     private final Map<String, Account> accounts = new LinkedHashMap<>();
+    private final Map<String, AdminUser> admins = new LinkedHashMap<>();
+    private final List<Transaction> transactions = new ArrayList<>();
     private int accountSequence = 1;
+    private int transactionSequence = 1;
 
     public void addCustomer(Customer customer) {
         customers.put(customer.getId(), customer);
@@ -30,9 +36,19 @@ public class Bank {
         return Optional.ofNullable(accounts.get(accountId));
     }
 
+    public void removeAccount(String accountId) {
+        accounts.remove(accountId);
+    }
+
     public String nextAccountId() {
         String newId = String.format("ACC-%04d", accountSequence);
         accountSequence += 1;
+        return newId;
+    }
+
+    public String nextTransactionId() {
+        String newId = String.format("TXN-%06d", transactionSequence);
+        transactionSequence += 1;
         return newId;
     }
 
@@ -47,11 +63,45 @@ public class Bank {
         this.accountSequence = accountSequence;
     }
 
+    public int getTransactionSequence() {
+        return transactionSequence;
+    }
+
+    public void setTransactionSequence(int transactionSequence) {
+        this.transactionSequence = transactionSequence;
+    }
+
     public List<Customer> getCustomersSnapshot() {
         return new ArrayList<>(customers.values());
     }
 
     public List<Account> getAccountsSnapshot() {
         return new ArrayList<>(accounts.values());
+    }
+
+    public void addAdmin(AdminUser adminUser) {
+        admins.put(adminUser.getUsername(), adminUser);
+    }
+
+    public Optional<AdminUser> findAdmin(String username) {
+        return Optional.ofNullable(admins.get(username));
+    }
+
+    public List<AdminUser> getAdminsSnapshot() {
+        return new ArrayList<>(admins.values());
+    }
+
+    public void addTransaction(Transaction transaction) {
+        transactions.add(transaction);
+    }
+
+    public List<Transaction> getTransactionsSnapshot() {
+        return new ArrayList<>(transactions);
+    }
+
+    public List<Transaction> findTransactionsForAccount(String accountId) {
+        return transactions.stream()
+                .filter(transaction -> transaction.getAccountId().equals(accountId))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/edu/washu/bank/exception/AuthenticationException.java
+++ b/src/main/java/edu/washu/bank/exception/AuthenticationException.java
@@ -1,0 +1,7 @@
+package edu.washu.bank.exception;
+
+public class AuthenticationException extends RuntimeException {
+    public AuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/edu/washu/bank/exception/InvalidAccountClosureException.java
+++ b/src/main/java/edu/washu/bank/exception/InvalidAccountClosureException.java
@@ -1,0 +1,7 @@
+package edu.washu.bank.exception;
+
+public class InvalidAccountClosureException extends RuntimeException {
+    public InvalidAccountClosureException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/edu/washu/bank/model/Account.java
+++ b/src/main/java/edu/washu/bank/model/Account.java
@@ -1,14 +1,15 @@
 package edu.washu.bank.model;
 
+import edu.washu.bank.exception.InvalidTransferException;
+
 import java.math.BigDecimal;
 import java.util.Objects;
-import edu.washu.bank.exception.InvalidTransferException;
 
 public class Account {
     private final String id;
     private final String customerId;
     private final AccountType type;
-    private BigDecimal balance;
+    private final BigDecimal balance;
 
     public Account(String id, String customerId, AccountType type, BigDecimal balance) {
         this.id = Objects.requireNonNull(id, "id must not be null");
@@ -34,20 +35,23 @@ public class Account {
     }
 
     public Account deposit(BigDecimal amount) {
-        return new Account(id, customerId, type, balance.add(amount));
+        return applyDelta(amount);
     }
-  
-    public void withdraw(BigDecimal amount) {
-        if (!isWithdrawalValid(amount)) {
+
+    public Account withdraw(BigDecimal amount) {
+        validateWithdrawalAmount(amount);
+        return applyDelta(amount.negate());
+    }
+
+    private Account applyDelta(BigDecimal amountDelta) {
+        return new Account(id, customerId, type, balance.add(amountDelta));
+    }
+
+    private void validateWithdrawalAmount(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0 || balance.compareTo(amount) < 0) {
             throw new InvalidTransferException(
-                "Withdrawal amount must be greater than zero and less than or equal to the current balance."
+                    "Withdrawal amount must be greater than zero and less than or equal to the current balance."
             );
         }
-        balance = balance.subtract(amount);
     }
-
-    private boolean isWithdrawalValid(BigDecimal amount) {
-        return amount.compareTo(BigDecimal.ZERO) > 0 && balance.compareTo(amount) >= 0;
-    }
-
 }

--- a/src/main/java/edu/washu/bank/model/AdminUser.java
+++ b/src/main/java/edu/washu/bank/model/AdminUser.java
@@ -1,0 +1,21 @@
+package edu.washu.bank.model;
+
+import java.util.Objects;
+
+public class AdminUser {
+    private final String username;
+    private final String password;
+
+    public AdminUser(String username, String password) {
+        this.username = Objects.requireNonNull(username, "username must not be null");
+        this.password = Objects.requireNonNull(password, "password must not be null");
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/edu/washu/bank/model/Customer.java
+++ b/src/main/java/edu/washu/bank/model/Customer.java
@@ -30,4 +30,8 @@ public class Customer {
     public void addAccountId(String accountId) {
         accountIds.add(Objects.requireNonNull(accountId, "accountId must not be null"));
     }
+
+    public void removeAccountId(String accountId) {
+        accountIds.remove(Objects.requireNonNull(accountId, "accountId must not be null"));
+    }
 }

--- a/src/main/java/edu/washu/bank/model/Transaction.java
+++ b/src/main/java/edu/washu/bank/model/Transaction.java
@@ -1,0 +1,60 @@
+package edu.washu.bank.model;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public class Transaction {
+    private final String id;
+    private final String accountId;
+    private final TransactionType type;
+    private final BigDecimal amount;
+    private final BigDecimal balanceAfter;
+    private final String relatedAccountId;
+    private final String description;
+
+    public Transaction(
+            String id,
+            String accountId,
+            TransactionType type,
+            BigDecimal amount,
+            BigDecimal balanceAfter,
+            String relatedAccountId,
+            String description
+    ) {
+        this.id = Objects.requireNonNull(id, "id must not be null");
+        this.accountId = Objects.requireNonNull(accountId, "accountId must not be null");
+        this.type = Objects.requireNonNull(type, "type must not be null");
+        this.amount = Objects.requireNonNull(amount, "amount must not be null");
+        this.balanceAfter = Objects.requireNonNull(balanceAfter, "balanceAfter must not be null");
+        this.relatedAccountId = relatedAccountId;
+        this.description = Objects.requireNonNull(description, "description must not be null");
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public TransactionType getType() {
+        return type;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public BigDecimal getBalanceAfter() {
+        return balanceAfter;
+    }
+
+    public String getRelatedAccountId() {
+        return relatedAccountId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/edu/washu/bank/model/TransactionType.java
+++ b/src/main/java/edu/washu/bank/model/TransactionType.java
@@ -1,0 +1,12 @@
+package edu.washu.bank.model;
+
+public enum TransactionType {
+    ACCOUNT_OPENED,
+    DEPOSIT,
+    WITHDRAWAL,
+    TRANSFER_OUT,
+    TRANSFER_IN,
+    FEE,
+    INTEREST,
+    ACCOUNT_CLOSED
+}

--- a/src/main/java/edu/washu/bank/persistence/SqliteBankStore.java
+++ b/src/main/java/edu/washu/bank/persistence/SqliteBankStore.java
@@ -3,7 +3,10 @@ package edu.washu.bank.persistence;
 import edu.washu.bank.core.Bank;
 import edu.washu.bank.model.Account;
 import edu.washu.bank.model.AccountType;
+import edu.washu.bank.model.AdminUser;
 import edu.washu.bank.model.Customer;
+import edu.washu.bank.model.Transaction;
+import edu.washu.bank.model.TransactionType;
 
 import java.math.BigDecimal;
 import java.nio.file.Path;
@@ -23,6 +26,8 @@ public final class SqliteBankStore {
 
     public static final String DEFAULT_DB_FILE_PROPERTY = "bank.db.file";
     public static final String DEFAULT_DB_FILENAME = "bank.db";
+    public static final String SEEDED_ADMIN_USERNAME = "admin";
+    public static final String SEEDED_ADMIN_PASSWORD = "admin123";
 
     private final String jdbcUrl;
 
@@ -59,6 +64,21 @@ public final class SqliteBankStore {
                             + "balance TEXT NOT NULL,"
                             + "FOREIGN KEY (customer_id) REFERENCES customers(id))"
             );
+            st.execute(
+                    "CREATE TABLE IF NOT EXISTS transactions ("
+                            + "id TEXT PRIMARY KEY NOT NULL,"
+                            + "account_id TEXT NOT NULL,"
+                            + "type TEXT NOT NULL,"
+                            + "amount TEXT NOT NULL,"
+                            + "balance_after TEXT NOT NULL,"
+                            + "related_account_id TEXT,"
+                            + "description TEXT NOT NULL)"
+            );
+            st.execute(
+                    "CREATE TABLE IF NOT EXISTS admins ("
+                            + "username TEXT PRIMARY KEY NOT NULL,"
+                            + "password TEXT NOT NULL)"
+            );
         }
     }
 
@@ -73,6 +93,8 @@ public final class SqliteBankStore {
                 rs.next();
                 if (rs.getInt(1) == 0) {
                     runInTransaction(c, () -> insertSeedRows(c));
+                } else {
+                    runInTransaction(c, () -> ensureSeedData(c));
                 }
             }
             return loadBank(c);
@@ -95,8 +117,12 @@ public final class SqliteBankStore {
 
     private static void insertSeedRows(Connection c) throws SQLException {
         try (PreparedStatement ps = c.prepareStatement(
-                "INSERT INTO bank_meta (key, value) VALUES ('account_sequence', ?)")) {
-            ps.setString(1, "1");
+                "INSERT INTO bank_meta (key, value) VALUES (?, ?)")) {
+            ps.setString(1, "account_sequence");
+            ps.setString(2, "1");
+            ps.executeUpdate();
+            ps.setString(1, "transaction_sequence");
+            ps.setString(2, "1");
             ps.executeUpdate();
         }
         try (PreparedStatement ps = c.prepareStatement(
@@ -105,20 +131,78 @@ public final class SqliteBankStore {
             ps.setString(2, "Demo User");
             ps.executeUpdate();
         }
+        try (PreparedStatement ps = c.prepareStatement(
+                "INSERT INTO admins (username, password) VALUES (?, ?)")) {
+            ps.setString(1, SEEDED_ADMIN_USERNAME);
+            ps.setString(2, SEEDED_ADMIN_PASSWORD);
+            ps.executeUpdate();
+        }
+    }
+
+    private static void ensureSeedData(Connection c) throws SQLException {
+        ensureMetaValue(c, "transaction_sequence", "1");
+        ensureAdminUser(c);
+    }
+
+    private static void ensureMetaValue(Connection c, String key, String defaultValue) throws SQLException {
+        try (PreparedStatement ps = c.prepareStatement("SELECT COUNT(*) FROM bank_meta WHERE key = ?")) {
+            ps.setString(1, key);
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                if (rs.getInt(1) == 0) {
+                    try (PreparedStatement insert = c.prepareStatement(
+                            "INSERT INTO bank_meta (key, value) VALUES (?, ?)")) {
+                        insert.setString(1, key);
+                        insert.setString(2, defaultValue);
+                        insert.executeUpdate();
+                    }
+                }
+            }
+        }
+    }
+
+    private static void ensureAdminUser(Connection c) throws SQLException {
+        try (PreparedStatement ps = c.prepareStatement("SELECT COUNT(*) FROM admins WHERE username = ?")) {
+            ps.setString(1, SEEDED_ADMIN_USERNAME);
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                if (rs.getInt(1) == 0) {
+                    try (PreparedStatement insert = c.prepareStatement(
+                            "INSERT INTO admins (username, password) VALUES (?, ?)")) {
+                        insert.setString(1, SEEDED_ADMIN_USERNAME);
+                        insert.setString(2, SEEDED_ADMIN_PASSWORD);
+                        insert.executeUpdate();
+                    }
+                }
+            }
+        }
     }
 
     private static Bank loadBank(Connection c) throws SQLException {
         Bank bank = new Bank();
-        int sequence;
-        try (PreparedStatement ps = c.prepareStatement("SELECT value FROM bank_meta WHERE key = 'account_sequence'")) {
+        try (PreparedStatement ps = c.prepareStatement("SELECT key, value FROM bank_meta")) {
             try (ResultSet rs = ps.executeQuery()) {
-                if (!rs.next()) {
+                boolean foundAccountSequence = false;
+                boolean foundTransactionSequence = false;
+                while (rs.next()) {
+                    String key = rs.getString("key");
+                    String value = rs.getString("value");
+                    if ("account_sequence".equals(key)) {
+                        bank.setAccountSequence(Integer.parseInt(value));
+                        foundAccountSequence = true;
+                    } else if ("transaction_sequence".equals(key)) {
+                        bank.setTransactionSequence(Integer.parseInt(value));
+                        foundTransactionSequence = true;
+                    }
+                }
+                if (!foundAccountSequence) {
                     throw new SQLException("Missing bank_meta.account_sequence");
                 }
-                sequence = Integer.parseInt(rs.getString(1));
+                if (!foundTransactionSequence) {
+                    bank.setTransactionSequence(1);
+                }
             }
         }
-        bank.setAccountSequence(sequence);
 
         try (PreparedStatement ps = c.prepareStatement("SELECT id, name FROM customers ORDER BY id")) {
             try (ResultSet rs = ps.executeQuery()) {
@@ -143,6 +227,32 @@ public final class SqliteBankStore {
             }
         }
 
+        try (PreparedStatement ps = c.prepareStatement("SELECT username, password FROM admins ORDER BY username")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    bank.addAdmin(new AdminUser(rs.getString("username"), rs.getString("password")));
+                }
+            }
+        }
+
+        try (PreparedStatement ps = c.prepareStatement(
+                "SELECT id, account_id, type, amount, balance_after, related_account_id, description "
+                        + "FROM transactions ORDER BY id")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    bank.addTransaction(new Transaction(
+                            rs.getString("id"),
+                            rs.getString("account_id"),
+                            TransactionType.valueOf(rs.getString("type")),
+                            new BigDecimal(rs.getString("amount")),
+                            new BigDecimal(rs.getString("balance_after")),
+                            rs.getString("related_account_id"),
+                            rs.getString("description")
+                    ));
+                }
+            }
+        }
+
         return bank;
     }
 
@@ -154,13 +264,19 @@ public final class SqliteBankStore {
             initSchema(c);
             runInTransaction(c, () -> {
                 try (Statement st = c.createStatement()) {
+                    st.executeUpdate("DELETE FROM transactions");
+                    st.executeUpdate("DELETE FROM admins");
                     st.executeUpdate("DELETE FROM accounts");
                     st.executeUpdate("DELETE FROM customers");
                     st.executeUpdate("DELETE FROM bank_meta");
                 }
                 try (PreparedStatement ps = c.prepareStatement(
-                        "INSERT INTO bank_meta (key, value) VALUES ('account_sequence', ?)")) {
-                    ps.setString(1, Integer.toString(bank.getAccountSequence()));
+                        "INSERT INTO bank_meta (key, value) VALUES (?, ?)")) {
+                    ps.setString(1, "account_sequence");
+                    ps.setString(2, Integer.toString(bank.getAccountSequence()));
+                    ps.executeUpdate();
+                    ps.setString(1, "transaction_sequence");
+                    ps.setString(2, Integer.toString(bank.getTransactionSequence()));
                     ps.executeUpdate();
                 }
                 try (PreparedStatement ps = c.prepareStatement("INSERT INTO customers (id, name) VALUES (?, ?)")) {
@@ -180,6 +296,28 @@ public final class SqliteBankStore {
                         ps.executeUpdate();
                     }
                 }
+                try (PreparedStatement ps = c.prepareStatement(
+                        "INSERT INTO admins (username, password) VALUES (?, ?)")) {
+                    for (AdminUser adminUser : bank.getAdminsSnapshot()) {
+                        ps.setString(1, adminUser.getUsername());
+                        ps.setString(2, adminUser.getPassword());
+                        ps.executeUpdate();
+                    }
+                }
+                try (PreparedStatement ps = c.prepareStatement(
+                        "INSERT INTO transactions (id, account_id, type, amount, balance_after, related_account_id, description) "
+                                + "VALUES (?, ?, ?, ?, ?, ?, ?)")) {
+                    for (Transaction transaction : bank.getTransactionsSnapshot()) {
+                        ps.setString(1, transaction.getId());
+                        ps.setString(2, transaction.getAccountId());
+                        ps.setString(3, transaction.getType().name());
+                        ps.setString(4, transaction.getAmount().toPlainString());
+                        ps.setString(5, transaction.getBalanceAfter().toPlainString());
+                        ps.setString(6, transaction.getRelatedAccountId());
+                        ps.setString(7, transaction.getDescription());
+                        ps.executeUpdate();
+                    }
+                }
             });
         }
     }
@@ -192,6 +330,8 @@ public final class SqliteBankStore {
             initSchema(c);
             runInTransaction(c, () -> {
                 try (Statement st = c.createStatement()) {
+                    st.executeUpdate("DELETE FROM transactions");
+                    st.executeUpdate("DELETE FROM admins");
                     st.executeUpdate("DELETE FROM accounts");
                     st.executeUpdate("DELETE FROM customers");
                     st.executeUpdate("DELETE FROM bank_meta");

--- a/src/main/java/edu/washu/bank/service/AccountService.java
+++ b/src/main/java/edu/washu/bank/service/AccountService.java
@@ -2,16 +2,20 @@ package edu.washu.bank.service;
 
 import edu.washu.bank.core.Bank;
 import edu.washu.bank.exception.AccountNotFoundException;
+import edu.washu.bank.exception.AuthenticationException;
 import edu.washu.bank.exception.CustomerNotFoundException;
 import edu.washu.bank.exception.InvalidDepositAmountException;
 import edu.washu.bank.exception.InvalidOpeningDepositException;
 import edu.washu.bank.exception.InvalidTransferException;
-import edu.washu.bank.exception.AccountNotFoundException;
 import edu.washu.bank.model.Account;
 import edu.washu.bank.model.AccountType;
+import edu.washu.bank.model.AdminUser;
 import edu.washu.bank.model.Customer;
+import edu.washu.bank.model.Transaction;
+import edu.washu.bank.model.TransactionType;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Objects;
 
 public class AccountService {
@@ -33,44 +37,190 @@ public class AccountService {
         Account account = new Account(accountId, customer.getId(), accountType, openingDeposit);
         bank.saveAccount(account);
         customer.addAccountId(accountId);
+        recordTransaction(
+                accountId,
+                TransactionType.ACCOUNT_OPENED,
+                openingDeposit,
+                openingDeposit,
+                null,
+                "Account opened"
+        );
         return account;
     }
 
     public Account depositIntoExistingAccount(String accountId, BigDecimal amount) {
-        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw new InvalidDepositAmountException("Deposit amount must be greater than 0");
-        }
-
-        Account existingAccount = bank.findAccount(accountId)
-                .orElseThrow(() -> new AccountNotFoundException(accountId));
-
+        validateDepositAmount(amount);
+        Account existingAccount = requireAccount(accountId);
         Account updatedAccount = existingAccount.deposit(amount);
         bank.saveAccount(updatedAccount);
+        recordTransaction(
+                accountId,
+                TransactionType.DEPOSIT,
+                amount,
+                updatedAccount.getBalance(),
+                null,
+                "Deposit"
+        );
         return updatedAccount;
     }
 
-    public void withdraw(String accountId, BigDecimal amount) {
-        Account account = bank.findAccount(accountId)
-                .orElseThrow(() -> new AccountNotFoundException(accountId));
-
-        BigDecimal currentBalance = account.getBalance();
-        
-        validateWithdrawalAmount(amount, currentBalance);
-        account.withdraw(amount);
-    }
-
-    private void validateWithdrawalAmount(BigDecimal amount, BigDecimal currentBalance) {
-        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw new InvalidTransferException("Withdrawal amount must be greater than zero.");
-        }
-        if (currentBalance.compareTo(amount) < 0) {
-            throw new InvalidTransferException("Insufficient funds for withdrawal.");
-        }
+    public Account withdraw(String accountId, BigDecimal amount) {
+        Account account = requireAccount(accountId);
+        validateDebitAmount(amount, account.getBalance(), "Withdrawal amount must be greater than zero.");
+        Account updatedAccount = account.withdraw(amount);
+        bank.saveAccount(updatedAccount);
+        recordTransaction(
+                accountId,
+                TransactionType.WITHDRAWAL,
+                amount,
+                updatedAccount.getBalance(),
+                null,
+                "Withdrawal"
+        );
+        return updatedAccount;
     }
 
     public BigDecimal getBalance(String accountId) {
-        Account account = bank.findAccount(accountId)
+        return requireAccount(accountId).getBalance();
+    }
+
+    public List<Transaction> getTransactionHistory(String accountId) {
+        List<Transaction> history = bank.findTransactionsForAccount(accountId);
+        if (history.isEmpty() && bank.findAccount(accountId).isEmpty()) {
+            throw new AccountNotFoundException(accountId);
+        }
+        return history;
+    }
+
+    public BigDecimal closeAccount(String accountId) {
+        Account account = requireAccount(accountId);
+        BigDecimal closingBalance = account.getBalance();
+        recordTransaction(
+                accountId,
+                TransactionType.ACCOUNT_CLOSED,
+                closingBalance,
+                BigDecimal.ZERO,
+                null,
+                "Account closed"
+        );
+        bank.removeAccount(accountId);
+        bank.findCustomer(account.getCustomerId()).ifPresent(customer -> customer.removeAccountId(accountId));
+        return closingBalance;
+    }
+
+    public void transfer(String fromAccountId, String toAccountId, BigDecimal amount) {
+        if (Objects.equals(fromAccountId, toAccountId)) {
+            throw new InvalidTransferException("Cannot transfer to the same account.");
+        }
+
+        Account fromAccount = requireAccount(fromAccountId);
+        Account toAccount = requireAccount(toAccountId);
+        validateDebitAmount(amount, fromAccount.getBalance(), "Transfer amount must be greater than zero.");
+
+        Account updatedFrom = fromAccount.withdraw(amount);
+        Account updatedTo = toAccount.deposit(amount);
+        bank.saveAccount(updatedFrom);
+        bank.saveAccount(updatedTo);
+        recordTransaction(
+                fromAccountId,
+                TransactionType.TRANSFER_OUT,
+                amount,
+                updatedFrom.getBalance(),
+                toAccountId,
+                "Transfer to " + toAccountId
+        );
+        recordTransaction(
+                toAccountId,
+                TransactionType.TRANSFER_IN,
+                amount,
+                updatedTo.getBalance(),
+                fromAccountId,
+                "Transfer from " + fromAccountId
+        );
+    }
+
+    public Account collectFee(String username, String password, String accountId, BigDecimal amount) {
+        authenticateAdmin(username, password);
+        Account account = requireAccount(accountId);
+        validateDebitAmount(amount, account.getBalance(), "Fee amount must be greater than zero.");
+        Account updatedAccount = account.withdraw(amount);
+        bank.saveAccount(updatedAccount);
+        recordTransaction(
+                accountId,
+                TransactionType.FEE,
+                amount,
+                updatedAccount.getBalance(),
+                null,
+                "Administrative fee"
+        );
+        return updatedAccount;
+    }
+
+    public Account addInterest(String username, String password, String accountId, BigDecimal amount) {
+        authenticateAdmin(username, password);
+        validatePositiveAmount(amount, "Interest amount must be greater than zero.");
+        Account account = requireAccount(accountId);
+        Account updatedAccount = account.deposit(amount);
+        bank.saveAccount(updatedAccount);
+        recordTransaction(
+                accountId,
+                TransactionType.INTEREST,
+                amount,
+                updatedAccount.getBalance(),
+                null,
+                "Interest payment"
+        );
+        return updatedAccount;
+    }
+
+    private void authenticateAdmin(String username, String password) {
+        AdminUser adminUser = bank.findAdmin(username)
+                .orElseThrow(() -> new AuthenticationException("Invalid admin credentials."));
+        if (!adminUser.getPassword().equals(password)) {
+            throw new AuthenticationException("Invalid admin credentials.");
+        }
+    }
+
+    private Account requireAccount(String accountId) {
+        return bank.findAccount(accountId)
                 .orElseThrow(() -> new AccountNotFoundException(accountId));
-        return account.getBalance();
+    }
+
+    private void validateDepositAmount(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new InvalidDepositAmountException("Deposit amount must be greater than 0");
+        }
+    }
+
+    private void validatePositiveAmount(BigDecimal amount, String message) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new InvalidTransferException(message);
+        }
+    }
+
+    private void validateDebitAmount(BigDecimal amount, BigDecimal balance, String amountErrorMessage) {
+        validatePositiveAmount(amount, amountErrorMessage);
+        if (balance.compareTo(amount) < 0) {
+            throw new InvalidTransferException("Insufficient funds.");
+        }
+    }
+
+    private void recordTransaction(
+            String accountId,
+            TransactionType type,
+            BigDecimal amount,
+            BigDecimal balanceAfter,
+            String relatedAccountId,
+            String description
+    ) {
+        bank.addTransaction(new Transaction(
+                bank.nextTransactionId(),
+                accountId,
+                type,
+                amount,
+                balanceAfter,
+                relatedAccountId,
+                description
+        ));
     }
 }

--- a/src/test/java/edu/washu/bank/persistence/SqliteBankStoreTest.java
+++ b/src/test/java/edu/washu/bank/persistence/SqliteBankStoreTest.java
@@ -2,6 +2,7 @@ package edu.washu.bank.persistence;
 
 import edu.washu.bank.core.Bank;
 import edu.washu.bank.model.AccountType;
+import edu.washu.bank.model.TransactionType;
 import edu.washu.bank.service.AccountService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -23,7 +24,9 @@ class SqliteBankStoreTest {
         Bank bank = store.loadOrInitialize();
 
         assertTrue(bank.findCustomer("CUST-001").isPresent());
+        assertTrue(bank.findAdmin(SqliteBankStore.SEEDED_ADMIN_USERNAME).isPresent());
         assertEquals(1, bank.getAccountSequence());
+        assertEquals(1, bank.getTransactionSequence());
     }
 
     @Test
@@ -50,6 +53,48 @@ class SqliteBankStoreTest {
     }
 
     @Test
+    void saveAndReloadPersistsTransactionHistoryAndAdminActions(@TempDir Path tempDir) throws SQLException {
+        Path db = tempDir.resolve("bank.db");
+        SqliteBankStore store = new SqliteBankStore(db);
+        Bank bank = store.loadOrInitialize();
+        AccountService accountService = new AccountService(bank);
+
+        var first = accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.CHECKING,
+                new BigDecimal("100.00")
+        );
+        var second = accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.SAVINGS,
+                new BigDecimal("50.00")
+        );
+        accountService.transfer(first.getId(), second.getId(), new BigDecimal("10.00"));
+        accountService.collectFee(
+                SqliteBankStore.SEEDED_ADMIN_USERNAME,
+                SqliteBankStore.SEEDED_ADMIN_PASSWORD,
+                first.getId(),
+                new BigDecimal("5.00")
+        );
+        accountService.addInterest(
+                SqliteBankStore.SEEDED_ADMIN_USERNAME,
+                SqliteBankStore.SEEDED_ADMIN_PASSWORD,
+                second.getId(),
+                new BigDecimal("2.00")
+        );
+        store.saveFullState(bank);
+
+        Bank reloaded = new SqliteBankStore(db).loadOrInitialize();
+        AccountService reloadedService = new AccountService(reloaded);
+
+        assertTrue(reloaded.findAdmin(SqliteBankStore.SEEDED_ADMIN_USERNAME).isPresent());
+        assertEquals(3, reloadedService.getTransactionHistory(first.getId()).size());
+        assertEquals(3, reloadedService.getTransactionHistory(second.getId()).size());
+        assertEquals(TransactionType.FEE, reloadedService.getTransactionHistory(first.getId()).get(2).getType());
+        assertEquals(TransactionType.INTEREST, reloadedService.getTransactionHistory(second.getId()).get(2).getType());
+    }
+
+    @Test
     void clearAllAndReseedRemovesAccounts(@TempDir Path tempDir) throws SQLException {
         Path db = tempDir.resolve("bank.db");
         SqliteBankStore store = new SqliteBankStore(db);
@@ -67,6 +112,8 @@ class SqliteBankStoreTest {
 
         assertTrue(after.findCustomer("CUST-001").isPresent());
         assertTrue(after.findAccount(account.getId()).isEmpty());
+        assertTrue(after.findAdmin(SqliteBankStore.SEEDED_ADMIN_USERNAME).isPresent());
         assertEquals(1, after.getAccountSequence());
+        assertEquals(1, after.getTransactionSequence());
     }
 }

--- a/src/test/java/edu/washu/bank/service/AccountServiceTest.java
+++ b/src/test/java/edu/washu/bank/service/AccountServiceTest.java
@@ -1,17 +1,23 @@
 package edu.washu.bank.service;
 
 import edu.washu.bank.core.Bank;
+import edu.washu.bank.exception.AccountNotFoundException;
+import edu.washu.bank.exception.AuthenticationException;
 import edu.washu.bank.exception.CustomerNotFoundException;
+import edu.washu.bank.exception.InvalidDepositAmountException;
 import edu.washu.bank.exception.InvalidOpeningDepositException;
+import edu.washu.bank.exception.InvalidTransferException;
 import edu.washu.bank.model.Account;
 import edu.washu.bank.model.AccountType;
+import edu.washu.bank.model.AdminUser;
 import edu.washu.bank.model.Customer;
+import edu.washu.bank.model.Transaction;
+import edu.washu.bank.model.TransactionType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import edu.washu.bank.exception.AccountNotFoundException;
-import edu.washu.bank.exception.InvalidDepositAmountException;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -25,6 +31,7 @@ class AccountServiceTest {
     void setUp() {
         bank = new Bank();
         bank.addCustomer(new Customer("CUST-001", "Alice"));
+        bank.addAdmin(new AdminUser("admin", "admin123"));
         accountService = new AccountService(bank);
     }
 
@@ -43,7 +50,7 @@ class AccountServiceTest {
     }
 
     @Test
-    void createAdditionalAccountAddsAccountToCustomer() {
+    void createAdditionalAccountAddsAccountToCustomerAndHistory() {
         Account account = accountService.createAdditionalAccount(
                 "CUST-001",
                 AccountType.SAVINGS,
@@ -51,8 +58,12 @@ class AccountServiceTest {
         );
 
         Customer customer = bank.findCustomer("CUST-001").orElseThrow();
+        List<Transaction> history = accountService.getTransactionHistory(account.getId());
+
         assertEquals(1, customer.getAccountIds().size());
         assertEquals(account.getId(), customer.getAccountIds().get(0));
+        assertEquals(1, history.size());
+        assertEquals(TransactionType.ACCOUNT_OPENED, history.get(0).getType());
     }
 
     @Test
@@ -82,52 +93,55 @@ class AccountServiceTest {
 
     @Test
     void withdrawWithSufficientFundsSucceeds() {
-        Account account = accountService.createAdditionalAccount("CUST-001", AccountType.CHECKING, new BigDecimal("100.00"));
-        accountService.withdraw(account.getId(), new BigDecimal("30.00"));
-        assertEquals(new BigDecimal("70.00"), account.getBalance());
+        Account account = createCheckingAccount("100.00");
+
+        Account updatedAccount = accountService.withdraw(account.getId(), new BigDecimal("30.00"));
+
+        assertEquals(new BigDecimal("70.00"), updatedAccount.getBalance());
+        assertEquals(new BigDecimal("70.00"), bank.findAccount(account.getId()).orElseThrow().getBalance());
     }
 
     @Test
     void withdrawWithInsufficientFundsThrows() {
-        Account account = accountService.createAdditionalAccount("CUST-001", AccountType.CHECKING, new BigDecimal("50.00"));
+        Account account = createCheckingAccount("50.00");
+
         assertThrows(
-                RuntimeException.class,
+                InvalidTransferException.class,
                 () -> accountService.withdraw(account.getId(), new BigDecimal("60.00"))
-        ); 
+        );
     }
 
     @Test
     void withdrawWithNegativeAmountThrows() {
-        Account account = accountService.createAdditionalAccount("CUST-001", AccountType.CHECKING, new BigDecimal("50.00"));
+        Account account = createCheckingAccount("50.00");
+
         assertThrows(
-                RuntimeException.class,
+                InvalidTransferException.class,
                 () -> accountService.withdraw(account.getId(), new BigDecimal("-10.00"))
         );
     }
 
     @Test
     void withdrawWithInvalidAmountThrows() {
-        Account account = accountService.createAdditionalAccount("CUST-001", AccountType.CHECKING, new BigDecimal("50.00"));
+        Account account = createCheckingAccount("50.00");
+
         assertThrows(
-                RuntimeException.class,
+                InvalidTransferException.class,
                 () -> accountService.withdraw(account.getId(), null)
         );
     }
 
-    @ Test
+    @Test
     void withdrawFromNonexistentAccountThrows() {
         assertThrows(
-                RuntimeException.class,
-                () -> accountService.withdraw("ACC-404", new BigDecimal("10.00"))        );
+                AccountNotFoundException.class,
+                () -> accountService.withdraw("ACC-404", new BigDecimal("10.00"))
+        );
     }
 
     @Test
     void getBalanceForExistingAccountReturnsCorrectBalance() {
-        Account account = accountService.createAdditionalAccount(
-                "CUST-001",
-                AccountType.CHECKING,
-                new BigDecimal("500.00")
-        );
+        Account account = createCheckingAccount("500.00");
 
         BigDecimal balance = accountService.getBalance(account.getId());
 
@@ -144,11 +158,7 @@ class AccountServiceTest {
 
     @Test
     void depositIntoExistingAccountSucceeds() {
-        Account account = accountService.createAdditionalAccount(
-                "CUST-001",
-                AccountType.CHECKING,
-                new BigDecimal("100.00")
-        );
+        Account account = createCheckingAccount("100.00");
 
         Account updatedAccount = accountService.depositIntoExistingAccount(
                 account.getId(),
@@ -169,11 +179,7 @@ class AccountServiceTest {
 
     @Test
     void depositWithZeroAmountThrows() {
-        Account account = accountService.createAdditionalAccount(
-                "CUST-001",
-                AccountType.CHECKING,
-                new BigDecimal("100.00")
-        );
+        Account account = createCheckingAccount("100.00");
 
         assertThrows(
                 InvalidDepositAmountException.class,
@@ -183,15 +189,117 @@ class AccountServiceTest {
 
     @Test
     void depositWithNegativeAmountThrows() {
-        Account account = accountService.createAdditionalAccount(
-                "CUST-001",
-                AccountType.CHECKING,
-                new BigDecimal("100.00")
-        );
+        Account account = createCheckingAccount("100.00");
 
         assertThrows(
                 InvalidDepositAmountException.class,
                 () -> accountService.depositIntoExistingAccount(account.getId(), new BigDecimal("-10.00"))
         );
+    }
+
+    @Test
+    void transactionHistoryIncludesDepositsAndWithdrawals() {
+        Account account = createCheckingAccount("100.00");
+
+        accountService.depositIntoExistingAccount(account.getId(), new BigDecimal("25.00"));
+        accountService.withdraw(account.getId(), new BigDecimal("10.00"));
+
+        List<Transaction> history = accountService.getTransactionHistory(account.getId());
+
+        assertEquals(3, history.size());
+        assertEquals(TransactionType.ACCOUNT_OPENED, history.get(0).getType());
+        assertEquals(TransactionType.DEPOSIT, history.get(1).getType());
+        assertEquals(TransactionType.WITHDRAWAL, history.get(2).getType());
+    }
+
+    @Test
+    void getTransactionHistoryForMissingAccountThrows() {
+        assertThrows(
+                AccountNotFoundException.class,
+                () -> accountService.getTransactionHistory("ACC-404")
+        );
+    }
+
+    @Test
+    void closeAccountRemovesItAndKeepsHistory() {
+        Account account = createCheckingAccount("120.00");
+
+        BigDecimal cashOutAmount = accountService.closeAccount(account.getId());
+
+        assertEquals(new BigDecimal("120.00"), cashOutAmount);
+        assertTrue(bank.findAccount(account.getId()).isEmpty());
+        assertTrue(bank.findCustomer("CUST-001").orElseThrow().getAccountIds().isEmpty());
+        assertEquals(2, accountService.getTransactionHistory(account.getId()).size());
+        assertEquals(
+                TransactionType.ACCOUNT_CLOSED,
+                accountService.getTransactionHistory(account.getId()).get(1).getType()
+        );
+    }
+
+    @Test
+    void transferMovesMoneyAndRecordsBothSides() {
+        Account source = createCheckingAccount("100.00");
+        Account target = accountService.createAdditionalAccount("CUST-001", AccountType.SAVINGS, new BigDecimal("40.00"));
+
+        accountService.transfer(source.getId(), target.getId(), new BigDecimal("30.00"));
+
+        assertEquals(new BigDecimal("70.00"), bank.findAccount(source.getId()).orElseThrow().getBalance());
+        assertEquals(new BigDecimal("70.00"), bank.findAccount(target.getId()).orElseThrow().getBalance());
+        assertEquals(TransactionType.TRANSFER_OUT, lastTransaction(source.getId()).getType());
+        assertEquals(TransactionType.TRANSFER_IN, lastTransaction(target.getId()).getType());
+        assertEquals(target.getId(), lastTransaction(source.getId()).getRelatedAccountId());
+    }
+
+    @Test
+    void transferToSameAccountThrows() {
+        Account account = createCheckingAccount("100.00");
+
+        assertThrows(
+                InvalidTransferException.class,
+                () -> accountService.transfer(account.getId(), account.getId(), BigDecimal.ONE)
+        );
+    }
+
+    @Test
+    void collectFeeRequiresValidAdminCredentials() {
+        Account account = createCheckingAccount("100.00");
+
+        assertThrows(
+                AuthenticationException.class,
+                () -> accountService.collectFee("admin", "wrong", account.getId(), new BigDecimal("5.00"))
+        );
+    }
+
+    @Test
+    void collectFeeDebitsAccountAndRecordsHistory() {
+        Account account = createCheckingAccount("100.00");
+
+        Account updatedAccount = accountService.collectFee("admin", "admin123", account.getId(), new BigDecimal("5.00"));
+
+        assertEquals(new BigDecimal("95.00"), updatedAccount.getBalance());
+        assertEquals(TransactionType.FEE, lastTransaction(account.getId()).getType());
+    }
+
+    @Test
+    void addInterestCreditsAccountAndRecordsHistory() {
+        Account account = createCheckingAccount("100.00");
+
+        Account updatedAccount = accountService.addInterest("admin", "admin123", account.getId(), new BigDecimal("3.00"));
+
+        assertEquals(new BigDecimal("103.00"), updatedAccount.getBalance());
+        assertEquals(TransactionType.INTEREST, lastTransaction(account.getId()).getType());
+    }
+
+    private Account createCheckingAccount(String openingBalance) {
+        return accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.CHECKING,
+                new BigDecimal(openingBalance)
+        );
+    }
+
+    private Transaction lastTransaction(String accountId) {
+        List<Transaction> history = accountService.getTransactionHistory(accountId);
+        return history.get(history.size() - 1);
     }
 }


### PR DESCRIPTION
## Summary
- Complete the remaining banking user stories by adding transaction history, account closing, transfers, admin fee collection, and admin interest payments.
- Persist transaction ledger data and SQLite-backed admin credentials so the new features survive across CLI runs.
- Update the CLI, tests, and README so the new commands are usable and documented.

## Test plan
- [x] Run `.\gradlew.bat test`
- [x] Manually smoke test `create-account`, `deposit`, `withdraw`, `transaction-history`, `transfer`, `collect-fee`, `add-interest`, and `close-account`
- [x] Verify admin-only commands succeed with seeded credentials `admin / admin123`