### PR TITLE
Freeze and unfreeze account

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,8 @@
 
 # Features planned to implement this iteration (iteration 2)
 
-* **#8** Close an existing account
-* **#9** Customer can transfer money from one account to another
-* **#10** Bank admin can collect fees from existing account
-* **#11** Bank admin can add interest to existing account
-* **#17** Admin login
-* **#18** Overdraft protection
-* **#19** Files to store user story info
-* **#20** Password protection
-
+10. A bank administrator should be able to freeze and unfreeze an account to block deposits and withdrawals. (Daniel)
+11. A bank customer should be able to view the total balance across all of their accounts. (Daniel)
 ---
 
 # What commands are needed to compile and run your code from the command line?
@@ -38,6 +31,8 @@ Run the app with the required script:
 * `./runApp.sh close-account ACC-0001`
 * `./runApp.sh collect-fee admin admin123 ACC-0001 5.00`
 * `./runApp.sh add-interest admin admin123 ACC-0001 3.00`
+* `./runApp.sh freeze-account admin admin123 ACC-0001`
+* `./runApp.sh unfreeze-account admin admin123 ACC-0001`
 * `./runApp.sh clear-data` (wipes the local database and re-seeds the demo customer `CUST-001`)
 
 Notes:
@@ -65,7 +60,8 @@ Implemented features:
 * User story **#7**: transfer money from one account to another
 * User story **#8**: bank administrator can collect fees from existing accounts
 * User story **#9**: bank administrator can add an interest payment to an existing account
-* Command-line commands: `create-account`, `deposit`, `withdraw`, `check-balance`, `transaction-history`, `close-account`, `transfer`, `collect-fee`, `add-interest`, `clear-data`
+* User story **#10** bank administrator can freeze and unfreeze an account to block deposits, withdrawals, and transfers
+* Command-line commands: `create-account`, `deposit`, `withdraw`, `check-balance`, `transaction-history`, `close-account`, `transfer`, `collect-fee`, `add-interest`, `freeze-account`, `unfreeze-account`, `clear-data`
 * SQLite-backed storage persists customers, accounts, transaction history, and admin credentials between CLI runs
 
 ---

--- a/src/main/java/edu/washu/bank/cli/BankCli.java
+++ b/src/main/java/edu/washu/bank/cli/BankCli.java
@@ -59,6 +59,12 @@ public class BankCli {
             case "add-interest":
                 runAddInterest(args);
                 return;
+            case "freeze-account":
+                runFreezeAccount(args);
+                return;
+            case "unfreeze-account":
+                runUnfreezeAccount(args);
+                return;
             case "clear-data":
                 runClearData();
                 return;
@@ -325,6 +331,42 @@ public class BankCli {
         }
     }
 
+    private void runFreezeAccount(String[] args) {
+        if (args.length != 4) {
+            System.out.println("Invalid arguments for freeze-account.");
+            printUsage();
+            return;
+        }
+
+        try {
+            Account updatedAccount = accountService.freezeAccount(args[1], args[2], args[3]);
+            store.saveFullState(bank);
+            System.out.println("Froze account " + updatedAccount.getId() + ".");
+        } catch (RuntimeException ex) {
+            System.out.println(ex.getMessage());
+        } catch (SQLException ex) {
+            System.err.println("Database error: " + ex.getMessage());
+        }
+    }
+
+    private void runUnfreezeAccount(String[] args) {
+        if (args.length != 4) {
+            System.out.println("Invalid arguments for unfreeze-account.");
+            printUsage();
+            return;
+        }
+
+        try {
+            Account updatedAccount = accountService.unfreezeAccount(args[1], args[2], args[3]);
+            store.saveFullState(bank);
+            System.out.println("Unfroze account " + updatedAccount.getId() + ".");
+        } catch (RuntimeException ex) {
+            System.out.println(ex.getMessage());
+        } catch (SQLException ex) {
+            System.err.println("Database error: " + ex.getMessage());
+        }
+    }
+
     private void runClearData() {
         try {
             store.clearAllAndReseed();
@@ -354,6 +396,8 @@ public class BankCli {
         System.out.println("  transfer <fromAccountId> <toAccountId> <amount>");
         System.out.println("  collect-fee <adminUsername> <adminPassword> <accountId> <amount>");
         System.out.println("  add-interest <adminUsername> <adminPassword> <accountId> <amount>");
+        System.out.println("  freeze-account <adminUsername> <adminPassword> <accountId>");
+        System.out.println("  unfreeze-account <adminUsername> <adminPassword> <accountId>");
         System.out.println("  check-balance <accountId>");
         System.out.println("  clear-data");
         System.out.println("Examples:");
@@ -365,5 +409,7 @@ public class BankCli {
         System.out.println("  transfer ACC-0001 ACC-0002 10.00");
         System.out.println("  collect-fee admin admin123 ACC-0001 5.00");
         System.out.println("  add-interest admin admin123 ACC-0001 3.00");
+        System.out.println("  freeze-account admin admin123 ACC-0001");
+        System.out.println("  unfreeze-account admin admin123 ACC-0001");
     }
 }

--- a/src/main/java/edu/washu/bank/exception/AccountFrozenException.java
+++ b/src/main/java/edu/washu/bank/exception/AccountFrozenException.java
@@ -1,0 +1,7 @@
+package edu.washu.bank.exception;
+
+public class AccountFrozenException extends RuntimeException {
+    public AccountFrozenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/edu/washu/bank/model/Account.java
+++ b/src/main/java/edu/washu/bank/model/Account.java
@@ -11,12 +11,18 @@ public class Account {
     private final String customerId;
     private final AccountType type;
     private final BigDecimal balance;
+    private final boolean frozen;
 
     public Account(String id, String customerId, AccountType type, BigDecimal balance) {
+        this(id, customerId, type, balance, false);
+    }
+
+    public Account(String id, String customerId, AccountType type, BigDecimal balance, boolean frozen) {
         this.id = Objects.requireNonNull(id, "id must not be null");
         this.customerId = Objects.requireNonNull(customerId, "customerId must not be null");
         this.type = Objects.requireNonNull(type, "type must not be null");
         this.balance = Objects.requireNonNull(balance, "balance must not be null");
+        this.frozen = frozen;
     }
 
     public String getId() {
@@ -35,6 +41,10 @@ public class Account {
         return balance;
     }
 
+    public boolean isFrozen() {
+        return frozen;
+    }
+
     public Account deposit(BigDecimal amount) {
         validateDepositAmount(amount);
         return applyDelta(amount);
@@ -45,8 +55,16 @@ public class Account {
         return applyDelta(amount.negate());
     }
 
+    public Account freeze() {
+        return new Account(id, customerId, type, balance, true);
+    }
+
+    public Account unfreeze() {
+        return new Account(id, customerId, type, balance, false);
+    }
+
     private Account applyDelta(BigDecimal amountDelta) {
-        return new Account(id, customerId, type, balance.add(amountDelta));
+        return new Account(id, customerId, type, balance.add(amountDelta), frozen);
     }
 
     private void validateDepositAmount(BigDecimal amount) {

--- a/src/main/java/edu/washu/bank/persistence/SqliteBankStore.java
+++ b/src/main/java/edu/washu/bank/persistence/SqliteBankStore.java
@@ -62,6 +62,7 @@ public final class SqliteBankStore {
                             + "customer_id TEXT NOT NULL,"
                             + "type TEXT NOT NULL,"
                             + "balance TEXT NOT NULL,"
+                            + "frozen INTEGER NOT NULL DEFAULT 0,"
                             + "FOREIGN KEY (customer_id) REFERENCES customers(id))"
             );
             st.execute(
@@ -80,6 +81,7 @@ public final class SqliteBankStore {
                             + "password TEXT NOT NULL)"
             );
         }
+        ensureAccountsFrozenColumn(connection);
     }
 
     /**
@@ -178,6 +180,25 @@ public final class SqliteBankStore {
         }
     }
 
+    private static void ensureAccountsFrozenColumn(Connection c) throws SQLException {
+        boolean hasFrozenColumn = false;
+        try (Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery("PRAGMA table_info(accounts)")) {
+            while (rs.next()) {
+                if ("frozen".equalsIgnoreCase(rs.getString("name"))) {
+                    hasFrozenColumn = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasFrozenColumn) {
+            try (Statement st = c.createStatement()) {
+                st.execute("ALTER TABLE accounts ADD COLUMN frozen INTEGER NOT NULL DEFAULT 0");
+            }
+        }
+    }
+
     private static Bank loadBank(Connection c) throws SQLException {
         Bank bank = new Bank();
         try (PreparedStatement ps = c.prepareStatement("SELECT key, value FROM bank_meta")) {
@@ -213,14 +234,15 @@ public final class SqliteBankStore {
         }
 
         try (PreparedStatement ps = c.prepareStatement(
-                "SELECT id, customer_id, type, balance FROM accounts ORDER BY id")) {
+                "SELECT id, customer_id, type, balance, frozen FROM accounts ORDER BY id")) {
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
                     String id = rs.getString("id");
                     String customerId = rs.getString("customer_id");
                     AccountType type = AccountType.valueOf(rs.getString("type"));
                     BigDecimal balance = new BigDecimal(rs.getString("balance"));
-                    Account account = new Account(id, customerId, type, balance);
+                    boolean frozen = rs.getInt("frozen") != 0;
+                    Account account = new Account(id, customerId, type, balance, frozen);
                     bank.saveAccount(account);
                     bank.findCustomer(customerId).ifPresent(customer -> customer.addAccountId(id));
                 }
@@ -287,12 +309,13 @@ public final class SqliteBankStore {
                     }
                 }
                 try (PreparedStatement ps = c.prepareStatement(
-                        "INSERT INTO accounts (id, customer_id, type, balance) VALUES (?, ?, ?, ?)")) {
+                        "INSERT INTO accounts (id, customer_id, type, balance, frozen) VALUES (?, ?, ?, ?, ?)")) {
                     for (Account account : bank.getAccountsSnapshot()) {
                         ps.setString(1, account.getId());
                         ps.setString(2, account.getCustomerId());
                         ps.setString(3, account.getType().name());
                         ps.setString(4, account.getBalance().toPlainString());
+                        ps.setInt(5, account.isFrozen() ? 1 : 0);
                         ps.executeUpdate();
                     }
                 }

--- a/src/main/java/edu/washu/bank/service/AccountService.java
+++ b/src/main/java/edu/washu/bank/service/AccountService.java
@@ -1,6 +1,7 @@
 package edu.washu.bank.service;
 
 import edu.washu.bank.core.Bank;
+import edu.washu.bank.exception.AccountFrozenException;
 import edu.washu.bank.exception.AccountNotFoundException;
 import edu.washu.bank.exception.AuthenticationException;
 import edu.washu.bank.exception.CustomerNotFoundException;
@@ -49,6 +50,7 @@ public class AccountService {
 
     public Account depositIntoExistingAccount(String accountId, BigDecimal amount) {
         Account existingAccount = requireAccount(accountId);
+        ensureAccountIsNotFrozen(existingAccount, "deposit into");
         Account updatedAccount = existingAccount.deposit(amount);
         bank.saveAccount(updatedAccount);
         recordTransaction(
@@ -64,6 +66,7 @@ public class AccountService {
 
     public Account withdraw(String accountId, BigDecimal amount) {
         Account account = requireAccount(accountId);
+        ensureAccountIsNotFrozen(account, "withdraw from");
         Account updatedAccount = account.withdraw(amount);
         bank.saveAccount(updatedAccount);
         recordTransaction(
@@ -112,6 +115,8 @@ public class AccountService {
 
         Account fromAccount = requireAccount(fromAccountId);
         Account toAccount = requireAccount(toAccountId);
+        ensureAccountIsNotFrozen(fromAccount, "transfer from");
+        ensureAccountIsNotFrozen(toAccount, "transfer into");
 
         Account updatedFrom = fromAccount.withdraw(amount);
         Account updatedTo = toAccount.deposit(amount);
@@ -138,6 +143,7 @@ public class AccountService {
     public Account collectFee(String username, String password, String accountId, BigDecimal amount) {
         authenticateAdmin(username, password);
         Account account = requireAccount(accountId);
+        ensureAccountIsNotFrozen(account, "withdraw from");
         Account updatedAccount = account.withdraw(amount);
         bank.saveAccount(updatedAccount);
         recordTransaction(
@@ -154,6 +160,7 @@ public class AccountService {
     public Account addInterest(String username, String password, String accountId, BigDecimal amount) {
         authenticateAdmin(username, password);
         Account account = requireAccount(accountId);
+        ensureAccountIsNotFrozen(account, "deposit into");
         Account updatedAccount = account.deposit(amount);
         bank.saveAccount(updatedAccount);
         recordTransaction(
@@ -164,6 +171,22 @@ public class AccountService {
                 null,
                 "Interest payment"
         );
+        return updatedAccount;
+    }
+
+    public Account freezeAccount(String username, String password, String accountId) {
+        authenticateAdmin(username, password);
+        Account account = requireAccount(accountId);
+        Account updatedAccount = account.freeze();
+        bank.saveAccount(updatedAccount);
+        return updatedAccount;
+    }
+
+    public Account unfreezeAccount(String username, String password, String accountId) {
+        authenticateAdmin(username, password);
+        Account account = requireAccount(accountId);
+        Account updatedAccount = account.unfreeze();
+        bank.saveAccount(updatedAccount);
         return updatedAccount;
     }
 
@@ -178,6 +201,14 @@ public class AccountService {
     private Account requireAccount(String accountId) {
         return bank.findAccount(accountId)
                 .orElseThrow(() -> new AccountNotFoundException(accountId));
+    }
+
+    private void ensureAccountIsNotFrozen(Account account, String action) {
+        if (account.isFrozen()) {
+            throw new AccountFrozenException(
+                    "Account " + account.getId() + " is frozen. Cannot " + action + " this account."
+            );
+        }
     }
 
     private void recordTransaction(

--- a/src/test/java/edu/washu/bank/persistence/SqliteBankStoreTest.java
+++ b/src/test/java/edu/washu/bank/persistence/SqliteBankStoreTest.java
@@ -1,6 +1,7 @@
 package edu.washu.bank.persistence;
 
 import edu.washu.bank.core.Bank;
+import edu.washu.bank.exception.AccountFrozenException;
 import edu.washu.bank.model.AccountType;
 import edu.washu.bank.model.TransactionType;
 import edu.washu.bank.service.AccountService;
@@ -115,5 +116,34 @@ class SqliteBankStoreTest {
         assertTrue(after.findAdmin(SqliteBankStore.SEEDED_ADMIN_USERNAME).isPresent());
         assertEquals(1, after.getAccountSequence());
         assertEquals(1, after.getTransactionSequence());
+    }
+
+    @Test
+    void saveAndReloadPersistsFrozenAccountState(@TempDir Path tempDir) throws SQLException {
+        Path db = tempDir.resolve("bank.db");
+        SqliteBankStore store = new SqliteBankStore(db);
+        Bank bank = store.loadOrInitialize();
+        AccountService accountService = new AccountService(bank);
+
+        var account = accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.CHECKING,
+                new BigDecimal("100.00")
+        );
+        accountService.freezeAccount(
+                SqliteBankStore.SEEDED_ADMIN_USERNAME,
+                SqliteBankStore.SEEDED_ADMIN_PASSWORD,
+                account.getId()
+        );
+        store.saveFullState(bank);
+
+        Bank reloaded = new SqliteBankStore(db).loadOrInitialize();
+        AccountService reloadedService = new AccountService(reloaded);
+
+        assertTrue(reloaded.findAccount(account.getId()).orElseThrow().isFrozen());
+        org.junit.jupiter.api.Assertions.assertThrows(
+                AccountFrozenException.class,
+                () -> reloadedService.depositIntoExistingAccount(account.getId(), BigDecimal.ONE)
+        );
     }
 }

--- a/src/test/java/edu/washu/bank/service/AccountServiceTest.java
+++ b/src/test/java/edu/washu/bank/service/AccountServiceTest.java
@@ -1,6 +1,7 @@
 package edu.washu.bank.service;
 
 import edu.washu.bank.core.Bank;
+import edu.washu.bank.exception.AccountFrozenException;
 import edu.washu.bank.exception.AccountNotFoundException;
 import edu.washu.bank.exception.AuthenticationException;
 import edu.washu.bank.exception.CustomerNotFoundException;
@@ -20,6 +21,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -281,6 +283,85 @@ class AccountServiceTest {
     }
 
     @Test
+    void freezeAccountRequiresValidAdminCredentials() {
+        Account account = createCheckingAccount("100.00");
+
+        assertThrows(
+                AuthenticationException.class,
+                () -> accountService.freezeAccount("admin", "wrong", account.getId())
+        );
+    }
+
+    @Test
+    void freezeAndUnfreezeAccountUpdatesFrozenState() {
+        Account account = createCheckingAccount("100.00");
+
+        Account frozenAccount = accountService.freezeAccount("admin", "admin123", account.getId());
+        Account unfrozenAccount = accountService.unfreezeAccount("admin", "admin123", account.getId());
+
+        assertTrue(frozenAccount.isFrozen());
+        assertFalse(unfrozenAccount.isFrozen());
+        assertFalse(bank.findAccount(account.getId()).orElseThrow().isFrozen());
+    }
+
+    @Test
+    void depositIntoFrozenAccountThrows() {
+        Account account = createCheckingAccount("100.00");
+        accountService.freezeAccount("admin", "admin123", account.getId());
+
+        assertThrows(
+                AccountFrozenException.class,
+                () -> accountService.depositIntoExistingAccount(account.getId(), new BigDecimal("10.00"))
+        );
+    }
+
+    @Test
+    void withdrawFromFrozenAccountThrows() {
+        Account account = createCheckingAccount("100.00");
+        accountService.freezeAccount("admin", "admin123", account.getId());
+
+        assertThrows(
+                AccountFrozenException.class,
+                () -> accountService.withdraw(account.getId(), new BigDecimal("10.00"))
+        );
+    }
+
+    @Test
+    void transferFromFrozenAccountThrows() {
+        Account source = createCheckingAccount("100.00");
+        Account target = accountService.createAdditionalAccount("CUST-001", AccountType.SAVINGS, new BigDecimal("40.00"));
+        accountService.freezeAccount("admin", "admin123", source.getId());
+
+        assertThrows(
+                AccountFrozenException.class,
+                () -> accountService.transfer(source.getId(), target.getId(), new BigDecimal("10.00"))
+        );
+    }
+
+    @Test
+    void transferIntoFrozenAccountThrows() {
+        Account source = createCheckingAccount("100.00");
+        Account target = accountService.createAdditionalAccount("CUST-001", AccountType.SAVINGS, new BigDecimal("40.00"));
+        accountService.freezeAccount("admin", "admin123", target.getId());
+
+        assertThrows(
+                AccountFrozenException.class,
+                () -> accountService.transfer(source.getId(), target.getId(), new BigDecimal("10.00"))
+        );
+    }
+
+    @Test
+    void collectFeeFromFrozenAccountThrows() {
+        Account account = createCheckingAccount("100.00");
+        accountService.freezeAccount("admin", "admin123", account.getId());
+
+        assertThrows(
+                AccountFrozenException.class,
+                () -> accountService.collectFee("admin", "admin123", account.getId(), new BigDecimal("5.00"))
+        );
+    }
+
+    @Test
     void addInterestCreditsAccountAndRecordsHistory() {
         Account account = createCheckingAccount("100.00");
 
@@ -288,6 +369,28 @@ class AccountServiceTest {
 
         assertEquals(new BigDecimal("103.00"), updatedAccount.getBalance());
         assertEquals(TransactionType.INTEREST, lastTransaction(account.getId()).getType());
+    }
+
+    @Test
+    void addInterestToFrozenAccountThrows() {
+        Account account = createCheckingAccount("100.00");
+        accountService.freezeAccount("admin", "admin123", account.getId());
+
+        assertThrows(
+                AccountFrozenException.class,
+                () -> accountService.addInterest("admin", "admin123", account.getId(), new BigDecimal("3.00"))
+        );
+    }
+
+    @Test
+    void operationsResumeAfterAccountIsUnfrozen() {
+        Account account = createCheckingAccount("100.00");
+        accountService.freezeAccount("admin", "admin123", account.getId());
+        accountService.unfreezeAccount("admin", "admin123", account.getId());
+
+        Account updatedAccount = accountService.depositIntoExistingAccount(account.getId(), new BigDecimal("15.00"));
+
+        assertEquals(new BigDecimal("115.00"), updatedAccount.getBalance());
     }
 
     private Account createCheckingAccount(String openingBalance) {


### PR DESCRIPTION
## Summary
- Add admin-only `freeze-account` and `unfreeze-account` commands to block activity on frozen accounts.
- Persist account frozen state in SQLite so the freeze survives across CLI runs and reloads.
- Update CLI help and `README.md`, and add unit/persistence tests covering frozen-account behavior.

## Test plan
- [x] Run `.\gradlew.bat test`
- [x] Verify `bash ./runApp.sh help` shows `freeze-account` and `unfreeze-account`
- [x] Confirm frozen accounts reject deposits, withdrawals, and transfers
- [x] Confirm unfrozen accounts can resume normal operations
- [x] Confirm frozen state survives save/reload