### PR TITLE
Add savings account interest-rate viewing and management features（issue#32 and issue#33）

### DIFF
--- a/src/main/java/edu/washu/bank/cli/BankCli.java
+++ b/src/main/java/edu/washu/bank/cli/BankCli.java
@@ -59,8 +59,14 @@ public class BankCli {
             case "add-interest":
                 runAddInterest(args);
                 return;
+            case "apply-interest":
+                runApplyInterest(args);
+                return;
             case "clear-data":
                 runClearData();
+                return;
+            case "set-interest-rate":
+                runSetInterestRate(args);
                 return;
             default:
                 System.out.println("Unknown command: " + args[0]);
@@ -325,6 +331,57 @@ public class BankCli {
         }
     }
 
+    private void runApplyInterest(String[] args) {
+        if (args.length != 4) {
+            System.out.println("Invalid arguments for apply-interest.");
+            printUsage();
+            return;
+        }
+
+        try {
+            Account updatedAccount = accountService.applyInterestByRate(args[1], args[2], args[3]);
+            store.saveFullState(bank);
+            System.out.println(
+                    "Applied interest to account " + updatedAccount.getId()
+                            + ". New balance: " + updatedAccount.getBalance()
+                            + ", rate: " + updatedAccount.getInterestRate()
+            );
+        } catch (RuntimeException ex) {
+            System.out.println(ex.getMessage());
+        } catch (SQLException ex) {
+            System.err.println("Database error: " + ex.getMessage());
+        }
+    }
+
+    private void runSetInterestRate(String[] args) {
+        if (args.length != 5) {
+            System.out.println("Invalid arguments for set-interest-rate.");
+            printUsage();
+            return;
+        }
+
+        BigDecimal interestRate;
+        try {
+            interestRate = new BigDecimal(args[4]);
+        } catch (NumberFormatException ex) {
+            System.out.println("Invalid interest rate: " + args[4]);
+            return;
+        }
+
+        try {
+            Account updatedAccount = accountService.setInterestRate(args[1], args[2], args[3], interestRate);
+            store.saveFullState(bank);
+            System.out.println(
+                    "Set interest rate for account " + updatedAccount.getId()
+                            + " to " + updatedAccount.getInterestRate()
+            );
+        } catch (RuntimeException ex) {
+            System.out.println(ex.getMessage());
+        } catch (SQLException ex) {
+            System.err.println("Database error: " + ex.getMessage());
+        }
+    }
+
     private void runClearData() {
         try {
             store.clearAllAndReseed();
@@ -356,6 +413,8 @@ public class BankCli {
         System.out.println("  add-interest <adminUsername> <adminPassword> <accountId> <amount>");
         System.out.println("  check-balance <accountId>");
         System.out.println("  clear-data");
+        System.out.println("  set-interest-rate <adminUsername> <adminPassword> <accountId> <rate>");
+        System.out.println("  apply-interest <adminUsername> <adminPassword> <accountId>");
         System.out.println("Examples:");
         System.out.println("  create-account CUST-001 CHECKING 100.00");
         System.out.println("  check-balance ACC-0001");
@@ -365,5 +424,7 @@ public class BankCli {
         System.out.println("  transfer ACC-0001 ACC-0002 10.00");
         System.out.println("  collect-fee admin admin123 ACC-0001 5.00");
         System.out.println("  add-interest admin admin123 ACC-0001 3.00");
+        System.out.println("  set-interest-rate admin admin123 ACC-0001 0.05");
+        System.out.println("  apply-interest admin admin123 ACC-0001");
     }
 }

--- a/src/main/java/edu/washu/bank/cli/BankCli.java
+++ b/src/main/java/edu/washu/bank/cli/BankCli.java
@@ -59,8 +59,8 @@ public class BankCli {
             case "add-interest":
                 runAddInterest(args);
                 return;
-            case "apply-interest":
-                runApplyInterest(args);
+            case "view-interest-rate":
+                runViewInterestRate(args);
                 return;
             case "clear-data":
                 runClearData();
@@ -331,27 +331,6 @@ public class BankCli {
         }
     }
 
-    private void runApplyInterest(String[] args) {
-        if (args.length != 4) {
-            System.out.println("Invalid arguments for apply-interest.");
-            printUsage();
-            return;
-        }
-
-        try {
-            Account updatedAccount = accountService.applyInterestByRate(args[1], args[2], args[3]);
-            store.saveFullState(bank);
-            System.out.println(
-                    "Applied interest to account " + updatedAccount.getId()
-                            + ". New balance: " + updatedAccount.getBalance()
-                            + ", rate: " + updatedAccount.getInterestRate()
-            );
-        } catch (RuntimeException ex) {
-            System.out.println(ex.getMessage());
-        } catch (SQLException ex) {
-            System.err.println("Database error: " + ex.getMessage());
-        }
-    }
 
     private void runSetInterestRate(String[] args) {
         if (args.length != 5) {
@@ -379,6 +358,23 @@ public class BankCli {
             System.out.println(ex.getMessage());
         } catch (SQLException ex) {
             System.err.println("Database error: " + ex.getMessage());
+        }
+    }
+
+    private void runViewInterestRate(String[] args) {
+        if (args.length != 2) {
+            System.out.println("Invalid arguments for view-interest-rate.");
+            printUsage();
+            return;
+        }
+
+        String accountId = args[1];
+
+        try {
+            BigDecimal interestRate = accountService.getInterestRate(accountId);
+            System.out.println("Account " + accountId + " interest rate: " + interestRate);
+        } catch (RuntimeException ex) {
+            System.out.println(ex.getMessage());
         }
     }
 
@@ -414,7 +410,7 @@ public class BankCli {
         System.out.println("  check-balance <accountId>");
         System.out.println("  clear-data");
         System.out.println("  set-interest-rate <adminUsername> <adminPassword> <accountId> <rate>");
-        System.out.println("  apply-interest <adminUsername> <adminPassword> <accountId>");
+        System.out.println("  view-interest-rate <accountId>");
         System.out.println("Examples:");
         System.out.println("  create-account CUST-001 CHECKING 100.00");
         System.out.println("  check-balance ACC-0001");
@@ -425,6 +421,6 @@ public class BankCli {
         System.out.println("  collect-fee admin admin123 ACC-0001 5.00");
         System.out.println("  add-interest admin admin123 ACC-0001 3.00");
         System.out.println("  set-interest-rate admin admin123 ACC-0001 0.05");
-        System.out.println("  apply-interest admin admin123 ACC-0001");
+        System.out.println("  view-interest-rate ACC-0001");
     }
 }

--- a/src/main/java/edu/washu/bank/model/Account.java
+++ b/src/main/java/edu/washu/bank/model/Account.java
@@ -11,12 +11,22 @@ public class Account {
     private final String customerId;
     private final AccountType type;
     private final BigDecimal balance;
+    private final BigDecimal interestRate;
 
     public Account(String id, String customerId, AccountType type, BigDecimal balance) {
+        this(id, customerId, type, balance, BigDecimal.ZERO);
+    }
+
+    public Account(String id, String customerId, AccountType type, BigDecimal balance, BigDecimal interestRate) {
         this.id = Objects.requireNonNull(id, "id must not be null");
         this.customerId = Objects.requireNonNull(customerId, "customerId must not be null");
         this.type = Objects.requireNonNull(type, "type must not be null");
         this.balance = Objects.requireNonNull(balance, "balance must not be null");
+        this.interestRate = Objects.requireNonNull(interestRate, "interestRate must not be null");
+
+        if (interestRate.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Interest rate must not be negative.");
+        }
     }
 
     public String getId() {
@@ -35,6 +45,10 @@ public class Account {
         return balance;
     }
 
+    public BigDecimal getInterestRate() {
+        return interestRate;
+    }
+
     public Account deposit(BigDecimal amount) {
         validateDepositAmount(amount);
         return applyDelta(amount);
@@ -45,8 +59,18 @@ public class Account {
         return applyDelta(amount.negate());
     }
 
+    public Account withInterestRate(BigDecimal newInterestRate) {
+        if (type != AccountType.SAVINGS) {
+            throw new IllegalArgumentException("Interest rates can only be set for savings accounts.");
+        }
+        if (newInterestRate == null || newInterestRate.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Interest rate must be 0 or greater.");
+        }
+        return new Account(id, customerId, type, balance, newInterestRate);
+    }
+
     private Account applyDelta(BigDecimal amountDelta) {
-        return new Account(id, customerId, type, balance.add(amountDelta));
+        return new Account(id, customerId, type, balance.add(amountDelta), interestRate);
     }
 
     private void validateDepositAmount(BigDecimal amount) {

--- a/src/main/java/edu/washu/bank/persistence/SqliteBankStore.java
+++ b/src/main/java/edu/washu/bank/persistence/SqliteBankStore.java
@@ -62,6 +62,7 @@ public final class SqliteBankStore {
                             + "customer_id TEXT NOT NULL,"
                             + "type TEXT NOT NULL,"
                             + "balance TEXT NOT NULL,"
+                            + "interest_rate TEXT NOT NULL DEFAULT '0',"
                             + "FOREIGN KEY (customer_id) REFERENCES customers(id))"
             );
             st.execute(
@@ -80,6 +81,7 @@ public final class SqliteBankStore {
                             + "password TEXT NOT NULL)"
             );
         }
+        ensureAccountsInterestRateColumn(connection);
     }
 
     /**
@@ -178,6 +180,28 @@ public final class SqliteBankStore {
         }
     }
 
+    private static void ensureAccountsInterestRateColumn(Connection c) throws SQLException {
+        if (hasColumn(c, "accounts", "interest_rate")) {
+            return;
+        }
+
+        try (Statement st = c.createStatement()) {
+            st.executeUpdate("ALTER TABLE accounts ADD COLUMN interest_rate TEXT NOT NULL DEFAULT '0'");
+        }
+    }
+
+    private static boolean hasColumn(Connection c, String tableName, String columnName) throws SQLException {
+        try (Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery("PRAGMA table_info(" + tableName + ")")) {
+            while (rs.next()) {
+                if (columnName.equalsIgnoreCase(rs.getString("name"))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
     private static Bank loadBank(Connection c) throws SQLException {
         Bank bank = new Bank();
         try (PreparedStatement ps = c.prepareStatement("SELECT key, value FROM bank_meta")) {
@@ -213,14 +237,15 @@ public final class SqliteBankStore {
         }
 
         try (PreparedStatement ps = c.prepareStatement(
-                "SELECT id, customer_id, type, balance FROM accounts ORDER BY id")) {
+                "SELECT id, customer_id, type, balance, interest_rate FROM accounts ORDER BY id")) {
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
                     String id = rs.getString("id");
                     String customerId = rs.getString("customer_id");
                     AccountType type = AccountType.valueOf(rs.getString("type"));
                     BigDecimal balance = new BigDecimal(rs.getString("balance"));
-                    Account account = new Account(id, customerId, type, balance);
+                    BigDecimal interestRate = new BigDecimal(rs.getString("interest_rate"));
+                    Account account = new Account(id, customerId, type, balance, interestRate);
                     bank.saveAccount(account);
                     bank.findCustomer(customerId).ifPresent(customer -> customer.addAccountId(id));
                 }
@@ -287,12 +312,13 @@ public final class SqliteBankStore {
                     }
                 }
                 try (PreparedStatement ps = c.prepareStatement(
-                        "INSERT INTO accounts (id, customer_id, type, balance) VALUES (?, ?, ?, ?)")) {
+                        "INSERT INTO accounts (id, customer_id, type, balance, interest_rate) VALUES (?, ?, ?, ?, ?)")) {
                     for (Account account : bank.getAccountsSnapshot()) {
                         ps.setString(1, account.getId());
                         ps.setString(2, account.getCustomerId());
                         ps.setString(3, account.getType().name());
                         ps.setString(4, account.getBalance().toPlainString());
+                        ps.setString(5, account.getInterestRate().toPlainString());
                         ps.executeUpdate();
                     }
                 }

--- a/src/main/java/edu/washu/bank/service/AccountService.java
+++ b/src/main/java/edu/washu/bank/service/AccountService.java
@@ -14,7 +14,6 @@ import edu.washu.bank.model.Transaction;
 import edu.washu.bank.model.TransactionType;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.List;
 import java.util.Objects;
 
@@ -178,38 +177,14 @@ public class AccountService {
         return updatedAccount;
     }
 
-    public Account applyInterestByRate(String username, String password, String accountId) {
-        authenticateAdmin(username, password);
-
+    public BigDecimal getInterestRate(String accountId) {
         Account account = requireAccount(accountId);
 
         if (account.getType() != AccountType.SAVINGS) {
-            throw new IllegalArgumentException("Interest can only be applied to savings accounts.");
+            throw new IllegalArgumentException("Interest rates are only available for savings accounts.");
         }
 
-        if (account.getInterestRate().compareTo(BigDecimal.ZERO) <= 0) {
-            throw new IllegalArgumentException("Interest rate must be greater than 0 to apply interest.");
-        }
-
-        BigDecimal interestAmount = account.getBalance()
-                .multiply(account.getInterestRate())
-                .setScale(2, RoundingMode.HALF_UP);
-
-        if (interestAmount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw new IllegalArgumentException("Interest payment must be greater than 0.");
-        }
-
-        Account updatedAccount = account.deposit(interestAmount);
-        bank.saveAccount(updatedAccount);
-        recordTransaction(
-                accountId,
-                TransactionType.INTEREST,
-                interestAmount,
-                updatedAccount.getBalance(),
-                null,
-                "Interest payment at rate " + account.getInterestRate()
-        );
-        return updatedAccount;
+        return account.getInterestRate();
     }
 
     private void authenticateAdmin(String username, String password) {

--- a/src/main/java/edu/washu/bank/service/AccountService.java
+++ b/src/main/java/edu/washu/bank/service/AccountService.java
@@ -14,6 +14,7 @@ import edu.washu.bank.model.Transaction;
 import edu.washu.bank.model.TransactionType;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.Objects;
 
@@ -163,6 +164,50 @@ public class AccountService {
                 updatedAccount.getBalance(),
                 null,
                 "Interest payment"
+        );
+        return updatedAccount;
+    }
+
+    public Account setInterestRate(String username, String password, String accountId, BigDecimal interestRate) {
+        authenticateAdmin(username, password);
+
+        Account account = requireAccount(accountId);
+        Account updatedAccount = account.withInterestRate(interestRate);
+
+        bank.saveAccount(updatedAccount);
+        return updatedAccount;
+    }
+
+    public Account applyInterestByRate(String username, String password, String accountId) {
+        authenticateAdmin(username, password);
+
+        Account account = requireAccount(accountId);
+
+        if (account.getType() != AccountType.SAVINGS) {
+            throw new IllegalArgumentException("Interest can only be applied to savings accounts.");
+        }
+
+        if (account.getInterestRate().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Interest rate must be greater than 0 to apply interest.");
+        }
+
+        BigDecimal interestAmount = account.getBalance()
+                .multiply(account.getInterestRate())
+                .setScale(2, RoundingMode.HALF_UP);
+
+        if (interestAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Interest payment must be greater than 0.");
+        }
+
+        Account updatedAccount = account.deposit(interestAmount);
+        bank.saveAccount(updatedAccount);
+        recordTransaction(
+                accountId,
+                TransactionType.INTEREST,
+                interestAmount,
+                updatedAccount.getBalance(),
+                null,
+                "Interest payment at rate " + account.getInterestRate()
         );
         return updatedAccount;
     }

--- a/src/test/java/edu/washu/bank/persistence/SqliteBankStoreTest.java
+++ b/src/test/java/edu/washu/bank/persistence/SqliteBankStoreTest.java
@@ -147,7 +147,7 @@ class SqliteBankStoreTest {
     }
 
     @Test
-    void saveAndReloadPersistsAppliedInterestByRate(@TempDir Path tempDir) throws SQLException {
+    void saveAndReloadPersistsSavingsAccountInterestRateForViewing(@TempDir Path tempDir) throws SQLException {
         Path db = tempDir.resolve("bank.db");
         SqliteBankStore store = new SqliteBankStore(db);
         Bank bank = store.loadOrInitialize();
@@ -165,17 +165,11 @@ class SqliteBankStoreTest {
                 account.getId(),
                 new BigDecimal("0.05")
         );
-        accountService.applyInterestByRate(
-                SqliteBankStore.SEEDED_ADMIN_USERNAME,
-                SqliteBankStore.SEEDED_ADMIN_PASSWORD,
-                account.getId()
-        );
         store.saveFullState(bank);
 
         Bank reloaded = new SqliteBankStore(db).loadOrInitialize();
-        Account reloadedAccount = reloaded.findAccount(account.getId()).orElseThrow();
+        AccountService reloadedService = new AccountService(reloaded);
 
-        assertEquals(new BigDecimal("105.00"), reloadedAccount.getBalance());
-        assertEquals(new BigDecimal("0.05"), reloadedAccount.getInterestRate());
+        assertEquals(new BigDecimal("0.05"), reloadedService.getInterestRate(account.getId()));
     }
 }

--- a/src/test/java/edu/washu/bank/persistence/SqliteBankStoreTest.java
+++ b/src/test/java/edu/washu/bank/persistence/SqliteBankStoreTest.java
@@ -3,6 +3,7 @@ package edu.washu.bank.persistence;
 import edu.washu.bank.core.Bank;
 import edu.washu.bank.model.AccountType;
 import edu.washu.bank.model.TransactionType;
+import edu.washu.bank.model.Account;
 import edu.washu.bank.service.AccountService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -115,5 +116,66 @@ class SqliteBankStoreTest {
         assertTrue(after.findAdmin(SqliteBankStore.SEEDED_ADMIN_USERNAME).isPresent());
         assertEquals(1, after.getAccountSequence());
         assertEquals(1, after.getTransactionSequence());
+    }
+
+    @Test
+    void saveAndReloadPersistsSavingsAccountInterestRate(@TempDir Path tempDir) throws SQLException {
+        Path db = tempDir.resolve("bank.db");
+        SqliteBankStore store = new SqliteBankStore(db);
+        Bank bank = store.loadOrInitialize();
+        AccountService accountService = new AccountService(bank);
+
+        var account = accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.SAVINGS,
+                new BigDecimal("100.00")
+        );
+
+        accountService.setInterestRate(
+                SqliteBankStore.SEEDED_ADMIN_USERNAME,
+                SqliteBankStore.SEEDED_ADMIN_PASSWORD,
+                account.getId(),
+                new BigDecimal("0.05")
+        );
+        store.saveFullState(bank);
+
+        Bank reloaded = new SqliteBankStore(db).loadOrInitialize();
+        Account reloadedAccount = reloaded.findAccount(account.getId()).orElseThrow();
+
+        assertEquals(AccountType.SAVINGS, reloadedAccount.getType());
+        assertEquals(new BigDecimal("0.05"), reloadedAccount.getInterestRate());
+    }
+
+    @Test
+    void saveAndReloadPersistsAppliedInterestByRate(@TempDir Path tempDir) throws SQLException {
+        Path db = tempDir.resolve("bank.db");
+        SqliteBankStore store = new SqliteBankStore(db);
+        Bank bank = store.loadOrInitialize();
+        AccountService accountService = new AccountService(bank);
+
+        var account = accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.SAVINGS,
+                new BigDecimal("100.00")
+        );
+
+        accountService.setInterestRate(
+                SqliteBankStore.SEEDED_ADMIN_USERNAME,
+                SqliteBankStore.SEEDED_ADMIN_PASSWORD,
+                account.getId(),
+                new BigDecimal("0.05")
+        );
+        accountService.applyInterestByRate(
+                SqliteBankStore.SEEDED_ADMIN_USERNAME,
+                SqliteBankStore.SEEDED_ADMIN_PASSWORD,
+                account.getId()
+        );
+        store.saveFullState(bank);
+
+        Bank reloaded = new SqliteBankStore(db).loadOrInitialize();
+        Account reloadedAccount = reloaded.findAccount(account.getId()).orElseThrow();
+
+        assertEquals(new BigDecimal("105.00"), reloadedAccount.getBalance());
+        assertEquals(new BigDecimal("0.05"), reloadedAccount.getInterestRate());
     }
 }

--- a/src/test/java/edu/washu/bank/service/AccountServiceTest.java
+++ b/src/test/java/edu/washu/bank/service/AccountServiceTest.java
@@ -364,9 +364,8 @@ class AccountServiceTest {
                 )
         );
     }
-
     @Test
-    void applyInterestByRateForSavingsAccountSucceeds() {
+    void getInterestRateForSavingsAccountSucceeds() {
         Account account = accountService.createAdditionalAccount(
                 "CUST-001",
                 AccountType.SAVINGS,
@@ -380,78 +379,26 @@ class AccountServiceTest {
                 new BigDecimal("0.05")
         );
 
-        Account updatedAccount = accountService.applyInterestByRate(
-                "admin",
-                "admin123",
-                account.getId()
-        );
+        BigDecimal interestRate = accountService.getInterestRate(account.getId());
 
-        assertEquals(new BigDecimal("105.00"), updatedAccount.getBalance());
-        assertEquals(new BigDecimal("0.05"), updatedAccount.getInterestRate());
-        assertEquals(
-                TransactionType.INTEREST,
-                lastTransaction(account.getId()).getType()
-        );
-        assertEquals(
-                new BigDecimal("105.00"),
-                bank.findAccount(account.getId()).orElseThrow().getBalance()
-        );
+        assertEquals(new BigDecimal("0.05"), interestRate);
     }
 
     @Test
-    void applyInterestByRateWithInvalidAdminCredentialsThrows() {
-        Account account = accountService.createAdditionalAccount(
-                "CUST-001",
-                AccountType.SAVINGS,
-                new BigDecimal("100.00")
-        );
-
-        accountService.setInterestRate(
-                "admin",
-                "admin123",
-                account.getId(),
-                new BigDecimal("0.05")
-        );
-
-        assertThrows(
-                AuthenticationException.class,
-                () -> accountService.applyInterestByRate(
-                        "admin",
-                        "wrong-password",
-                        account.getId()
-                )
-        );
-    }
-
-    @Test
-    void applyInterestByRateForCheckingAccountThrows() {
+    void getInterestRateForCheckingAccountThrows() {
         Account account = createCheckingAccount("100.00");
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> accountService.applyInterestByRate(
-                        "admin",
-                        "admin123",
-                        account.getId()
-                )
+                () -> accountService.getInterestRate(account.getId())
         );
     }
 
     @Test
-    void applyInterestByRateWithoutPositiveRateThrows() {
-        Account account = accountService.createAdditionalAccount(
-                "CUST-001",
-                AccountType.SAVINGS,
-                new BigDecimal("100.00")
-        );
-
+    void getInterestRateForMissingAccountThrows() {
         assertThrows(
-                IllegalArgumentException.class,
-                () -> accountService.applyInterestByRate(
-                        "admin",
-                        "admin123",
-                        account.getId()
-                )
+                AccountNotFoundException.class,
+                () -> accountService.getInterestRate("ACC-404")
         );
     }
 

--- a/src/test/java/edu/washu/bank/service/AccountServiceTest.java
+++ b/src/test/java/edu/washu/bank/service/AccountServiceTest.java
@@ -290,6 +290,172 @@ class AccountServiceTest {
         assertEquals(TransactionType.INTEREST, lastTransaction(account.getId()).getType());
     }
 
+    @Test
+    void setInterestRateForSavingsAccountSucceeds() {
+        Account account = accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.SAVINGS,
+                new BigDecimal("100.00")
+        );
+
+        Account updatedAccount = accountService.setInterestRate(
+                "admin",
+                "admin123",
+                account.getId(),
+                new BigDecimal("0.05")
+        );
+
+        assertEquals(new BigDecimal("0.05"), updatedAccount.getInterestRate());
+        assertEquals(
+                new BigDecimal("0.05"),
+                bank.findAccount(account.getId()).orElseThrow().getInterestRate()
+        );
+    }
+
+    @Test
+    void setInterestRateWithInvalidAdminCredentialsThrows() {
+        Account account = accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.SAVINGS,
+                new BigDecimal("100.00")
+        );
+
+        assertThrows(
+                AuthenticationException.class,
+                () -> accountService.setInterestRate(
+                        "admin",
+                        "wrong-password",
+                        account.getId(),
+                        new BigDecimal("0.05")
+                )
+        );
+    }
+
+    @Test
+    void setInterestRateForCheckingAccountThrows() {
+        Account account = createCheckingAccount("100.00");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> accountService.setInterestRate(
+                        "admin",
+                        "admin123",
+                        account.getId(),
+                        new BigDecimal("0.05")
+                )
+        );
+    }
+
+    @Test
+    void setInterestRateWithNegativeRateThrows() {
+        Account account = accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.SAVINGS,
+                new BigDecimal("100.00")
+        );
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> accountService.setInterestRate(
+                        "admin",
+                        "admin123",
+                        account.getId(),
+                        new BigDecimal("-0.01")
+                )
+        );
+    }
+
+    @Test
+    void applyInterestByRateForSavingsAccountSucceeds() {
+        Account account = accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.SAVINGS,
+                new BigDecimal("100.00")
+        );
+
+        accountService.setInterestRate(
+                "admin",
+                "admin123",
+                account.getId(),
+                new BigDecimal("0.05")
+        );
+
+        Account updatedAccount = accountService.applyInterestByRate(
+                "admin",
+                "admin123",
+                account.getId()
+        );
+
+        assertEquals(new BigDecimal("105.00"), updatedAccount.getBalance());
+        assertEquals(new BigDecimal("0.05"), updatedAccount.getInterestRate());
+        assertEquals(
+                TransactionType.INTEREST,
+                lastTransaction(account.getId()).getType()
+        );
+        assertEquals(
+                new BigDecimal("105.00"),
+                bank.findAccount(account.getId()).orElseThrow().getBalance()
+        );
+    }
+
+    @Test
+    void applyInterestByRateWithInvalidAdminCredentialsThrows() {
+        Account account = accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.SAVINGS,
+                new BigDecimal("100.00")
+        );
+
+        accountService.setInterestRate(
+                "admin",
+                "admin123",
+                account.getId(),
+                new BigDecimal("0.05")
+        );
+
+        assertThrows(
+                AuthenticationException.class,
+                () -> accountService.applyInterestByRate(
+                        "admin",
+                        "wrong-password",
+                        account.getId()
+                )
+        );
+    }
+
+    @Test
+    void applyInterestByRateForCheckingAccountThrows() {
+        Account account = createCheckingAccount("100.00");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> accountService.applyInterestByRate(
+                        "admin",
+                        "admin123",
+                        account.getId()
+                )
+        );
+    }
+
+    @Test
+    void applyInterestByRateWithoutPositiveRateThrows() {
+        Account account = accountService.createAdditionalAccount(
+                "CUST-001",
+                AccountType.SAVINGS,
+                new BigDecimal("100.00")
+        );
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> accountService.applyInterestByRate(
+                        "admin",
+                        "admin123",
+                        account.getId()
+                )
+        );
+    }
+
+
     private Account createCheckingAccount(String openingBalance) {
         return accountService.createAdditionalAccount(
                 "CUST-001",


### PR DESCRIPTION
Summary
Add an admin-only set-interest-rate command for savings accounts.
Add a customer-facing view-interest-rate command so users can check the stored interest rate for a savings account.
Update service and CLI behavior to support savings-account interest-rate management and viewing.
Add unit and persistence tests covering interest-rate behavior.

Test plan
Run .\gradlew.bat test
Verify .\gradlew.bat run --args="help" shows set-interest-rate and view-interest-rate
Confirm set-interest-rate works for savings accounts
Confirm set-interest-rate rejects checking accounts
Confirm view-interest-rate shows the stored rate for savings accounts
Confirm view-interest-rate rejects checking accounts
Confirm interest rate survives save/reload