### PR TITLE
Add transaction history filtering by type

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 
 # Features planned to implement in iteration 3
 
-1. Reconstruct the user interface into a text-based user interface.
+18. Reconstruct the user interface into a text-based user interface.
+19. customer can filter transaction history by transaction type
 
 ---
 
@@ -80,6 +81,8 @@ Password: admin123
 * User story **#14**: customer accounts support password-protected operations
 * User story **#15**: customer can view the interest rate for a savings account
 * User story **#16**: bank administrator can manage the interest rate for a savings account
+* User story **#18**: Reconstruct the user interface into a text-based user interface.
+* User story **#19**: customer can filter transaction history by transaction type
 
 ## Command-line commands
 

--- a/README.md
+++ b/README.md
@@ -9,20 +9,11 @@
 
 ---
 
-# Features planned to implement in iteration 3:
+# Features planned to implement in iteration 3
+
 1. Reconstruct the user interface into a text-based user interface.
 
-<<<<<<< UI-reconstruct
-=======
-10. A bank administrator should be able to freeze and unfreeze an account to block deposits and withdrawals. (Daniel)
-11. A bank customer should be able to view the total balance across all of their accounts. (Daniel)
-12. A bank customer should be able to list all of their accounts. (Bobby)
-13. A bank administrator should be able to view all customers in the bank. (Bobby)
-14. A bank customer should be able to set password for their account (Rosie)
-15. A bank customer should be able to view the interest rate for a savings account. (Nina)
-16. A bank administrator should be able to manage the interest rate for a savings account. (Nina)
 ---
->>>>>>> main
 
 # Getting Started
 
@@ -30,11 +21,6 @@ From the project root:
 
 Run the app with the required script:
 
-<<<<<<< UI-reconstruct
-* `./runApp.sh`
-
-## Notes:
-=======
 * `./runApp.sh help`
 * `./runApp.sh create-account CUST-001 123 CHECKING 100.00`
 * `./runApp.sh deposit ACC-0001 50.00` (use the account id printed by `create-account`)
@@ -48,12 +34,13 @@ Run the app with the required script:
 * `./runApp.sh add-interest admin admin123 ACC-0001 3.00`
 * `./runApp.sh freeze-account admin admin123 ACC-0001`
 * `./runApp.sh unfreeze-account admin admin123 ACC-0001`
+* `./runApp.sh view-interest-rate ACC-0001`
+* `./runApp.sh set-interest-rate admin admin123 ACC-0001 0.03`
 * `./runApp.sh clear-data` (wipes the local database and re-seeds the demo customer `CUST-001`)
 * `./runApp.sh list-accounts CUST-001`
 * `./runApp.sh list-customers admin admin123`
 
-Notes:
->>>>>>> main
+## Notes
 
 * `runApp.sh` compiles the Java sources and runs the app without requiring Gradle to launch it.
 * On the first run, the script downloads `sqlite-jdbc-3.47.2.0.jar` into `lib/`.
@@ -61,21 +48,21 @@ Notes:
 * Gradle is still used for tests: `./gradlew test` on macOS/Linux or `.\gradlew.bat test` in PowerShell on Windows.
 
 ## Initial customer and admin account
+
 ### Customer
-ID: CUST-001
-Name: Demo User
+ID: CUST-001  
+Name: Demo User  
 Password: password
 
 ### Admin
-Username: admin
+Username: admin  
 Password: admin123
-
 
 **Persistence:** Account data is stored in a local SQLite file named `bank.db` in the working directory (created on first run). Separate `./runApp.sh` invocations share this file, so balances and transaction history survive between commands. To use a different path: add `-Dbank.db.file=/absolute/path/to/bank.db` to the Java process before launching the app.
 
 **Seeded admin credentials:** username `admin`, password `admin123`
 
-Implemented features:
+## Implemented features
 
 * User story **#1**: deposit into an existing account
 * User story **#2**: withdraw from an account
@@ -86,21 +73,42 @@ Implemented features:
 * User story **#7**: transfer money from one account to another
 * User story **#8**: bank administrator can collect fees from existing accounts
 * User story **#9**: bank administrator can add an interest payment to an existing account
-* User story **#10** bank administrator can freeze and unfreeze an account to block deposits, withdrawals, and transfers
-* Command-line commands: `create-account`, `deposit`, `withdraw`, `check-balance`, `transaction-history`, `close-account`, `transfer`, `collect-fee`, `add-interest`, `freeze-account`, `unfreeze-account`, `clear-data`
+* User story **#10**: bank administrator can freeze and unfreeze an account to block deposits, withdrawals, and transfers
 * User story **#11**: customer can view the total balance across all of their accounts
-* Command-line commands: `create-account`, `deposit`, `withdraw`, `check-balance`, `total-balance`, `transaction-history`, `close-account`, `transfer`, `collect-fee`, `add-interest`, `clear-data`
 * User story **#12**: customer can list all of their accounts
-* Command-line command: `list-accounts`
 * User story **#13**: bank administrator can view all customers in the bank
-* Command-line command: `list-customers`
 * User story **#14**: customer accounts support password-protected operations
-* Password-protected commands: `create-account`, `withdraw`, `close-account`, `transfer`
 * User story **#15**: customer can view the interest rate for a savings account
-* Command-line command: `view-interest-rate`
 * User story **#16**: bank administrator can manage the interest rate for a savings account
-* Command-line command: `set-interest-rate`
-* SQLite-backed storage persists customers, accounts, transaction history, and admin credentials between CLI runs
+
+## Command-line commands
+
+* `create-account`
+* `deposit`
+* `withdraw`
+* `check-balance`
+* `total-balance`
+* `transaction-history`
+* `transfer`
+* `close-account`
+* `collect-fee`
+* `add-interest`
+* `freeze-account`
+* `unfreeze-account`
+* `list-accounts`
+* `list-customers`
+* `view-interest-rate`
+* `set-interest-rate`
+* `clear-data`
+
+## Password-protected commands
+
+* `create-account`
+* `withdraw`
+* `close-account`
+* `transfer`
+
+SQLite-backed storage persists customers, accounts, transaction history, and admin credentials between CLI runs.
 
 ---
 
@@ -118,15 +126,18 @@ Implemented features:
 
 ---
 
-# Features planned to implement this iteration (iteration 2)
+# Features planned to implement this iteration (Iteration 2)
 
 10. A bank administrator should be able to freeze and unfreeze an account to block deposits and withdrawals. (Daniel)
 11. A bank customer should be able to view the total balance across all of their accounts. (Daniel)
 12. A bank customer should be able to list all of their accounts. (Bobby)
 13. A bank administrator should be able to view all customers in the bank. (Bobby)
+14. A bank customer should be able to set password for their account. (Rosie)
+15. A bank customer should be able to view the interest rate for a savings account. (Nina)
+16. A bank administrator should be able to manage the interest rate for a savings account. (Nina)
+
 ---
 
 # Is there anything that you implemented but doesn't currently work?
 
 No known issues at this time for user story **#5**.
-

--- a/src/main/java/edu/washu/bank/cli/BankCli.java
+++ b/src/main/java/edu/washu/bank/cli/BankCli.java
@@ -6,9 +6,9 @@ import edu.washu.bank.model.Account;
 import edu.washu.bank.model.AccountType;
 import edu.washu.bank.model.Customer;
 import edu.washu.bank.model.Transaction;
+import edu.washu.bank.model.TransactionType;
 import edu.washu.bank.persistence.SqliteBankStore;
 import edu.washu.bank.service.AccountService;
-import edu.washu.bank.model.Customer;
 
 import java.math.BigDecimal;
 import java.nio.file.Path;
@@ -234,7 +234,10 @@ public class BankCli {
         if (accountId == null) return;
 
         try {
-            List<Transaction> history = accountService.getTransactionHistory(accountId);
+            TransactionType filterType = promptTransactionTypeFilter();
+            List<Transaction> history = filterType == null
+                    ? accountService.getTransactionHistory(accountId)
+                    : accountService.getTransactionHistory(accountId, filterType);
             if (history.isEmpty()) {
                 System.out.println("No transactions found.");
                 return;
@@ -251,6 +254,21 @@ public class BankCli {
         } catch (RuntimeException ex) {
             System.out.println("Error: " + ex.getMessage());
         }
+    }
+
+    private TransactionType promptTransactionTypeFilter() {
+        TransactionType[] transactionTypes = TransactionType.values();
+        System.out.println("Filter by transaction type:");
+        System.out.println("0. All transaction types");
+        for (int i = 0; i < transactionTypes.length; i++) {
+            System.out.println((i + 1) + ". " + transactionTypes[i]);
+        }
+
+        int selection = getUserSelection(transactionTypes.length);
+        if (selection == 0) {
+            return null;
+        }
+        return transactionTypes[selection - 1];
     }
 
     private void closeAccount(Customer customer) {

--- a/src/main/java/edu/washu/bank/service/AccountService.java
+++ b/src/main/java/edu/washu/bank/service/AccountService.java
@@ -17,6 +17,7 @@ import edu.washu.bank.model.TransactionType;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class AccountService {
     private final Bank bank;
@@ -119,6 +120,13 @@ public class AccountService {
             throw new AccountNotFoundException(accountId);
         }
         return history;
+    }
+
+    public List<Transaction> getTransactionHistory(String accountId, TransactionType type) {
+        Objects.requireNonNull(type, "type must not be null");
+        return getTransactionHistory(accountId).stream()
+                .filter(transaction -> transaction.getType() == type)
+                .collect(Collectors.toList());
     }
 
     public BigDecimal closeAccount(String accountId) {

--- a/src/test/java/edu/washu/bank/service/AccountServiceTest.java
+++ b/src/test/java/edu/washu/bank/service/AccountServiceTest.java
@@ -268,10 +268,43 @@ class AccountServiceTest {
     }
 
     @Test
+    void getTransactionHistoryByTypeReturnsOnlyMatchingTransactions() {
+        Account account = createCheckingAccount("100.00");
+
+        accountService.depositIntoExistingAccount(account.getId(), new BigDecimal("25.00"));
+        accountService.depositIntoExistingAccount(account.getId(), new BigDecimal("5.00"));
+        accountService.withdraw(account.getId(), new BigDecimal("10.00"), CUSTOMER_PASSWORD);
+
+        List<Transaction> history = accountService.getTransactionHistory(account.getId(), TransactionType.DEPOSIT);
+
+        assertEquals(2, history.size());
+        assertTrue(history.stream().allMatch(transaction -> transaction.getType() == TransactionType.DEPOSIT));
+    }
+
+    @Test
+    void getTransactionHistoryByTypeReturnsEmptyListWhenAccountHasNoMatches() {
+        Account account = createCheckingAccount("100.00");
+
+        accountService.depositIntoExistingAccount(account.getId(), new BigDecimal("25.00"));
+
+        List<Transaction> history = accountService.getTransactionHistory(account.getId(), TransactionType.FEE);
+
+        assertTrue(history.isEmpty());
+    }
+
+    @Test
     void getTransactionHistoryForMissingAccountThrows() {
         assertThrows(
                 AccountNotFoundException.class,
                 () -> accountService.getTransactionHistory("ACC-404")
+        );
+    }
+
+    @Test
+    void getTransactionHistoryByTypeForMissingAccountThrows() {
+        assertThrows(
+                AccountNotFoundException.class,
+                () -> accountService.getTransactionHistory("ACC-404", TransactionType.DEPOSIT)
         );
     }
 


### PR DESCRIPTION
## Summary
- add a filtered transaction history API in `AccountService` for a single `TransactionType`
- update the customer CLI flow to let users view all transactions or filter history by one exact type
- add service tests for matching results, empty filtered results, and missing-account behavior
- document the new feature in `README.md`

## Test plan
- [x] Run `.\gradlew.bat test`
- [x] Log in as a customer and open Transaction History
- [x] Select an account and verify `All transaction types` shows the full history
- [x] Select a specific type such as `DEPOSIT` and verify only matching transactions appear
- [x] Verify an account with no matching transactions shows `No transactions found.`