### PR TITLE
Feature/issue44 balance alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,11 @@
 
 ---
 
-# Features planned to implement in iteration 3:
+# Features planned to implement in iteration 3
+
 1. Reconstruct the user interface into a text-based user interface.
 
-<<<<<<< UI-reconstruct
-=======
-10. A bank administrator should be able to freeze and unfreeze an account to block deposits and withdrawals. (Daniel)
-11. A bank customer should be able to view the total balance across all of their accounts. (Daniel)
-12. A bank customer should be able to list all of their accounts. (Bobby)
-13. A bank administrator should be able to view all customers in the bank. (Bobby)
-14. A bank customer should be able to set password for their account (Rosie)
-15. A bank customer should be able to view the interest rate for a savings account. (Nina)
-16. A bank administrator should be able to manage the interest rate for a savings account. (Nina)
 ---
->>>>>>> main
 
 # Getting Started
 
@@ -30,11 +21,6 @@ From the project root:
 
 Run the app with the required script:
 
-<<<<<<< UI-reconstruct
-* `./runApp.sh`
-
-## Notes:
-=======
 * `./runApp.sh help`
 * `./runApp.sh create-account CUST-001 123 CHECKING 100.00`
 * `./runApp.sh deposit ACC-0001 50.00` (use the account id printed by `create-account`)
@@ -48,12 +34,13 @@ Run the app with the required script:
 * `./runApp.sh add-interest admin admin123 ACC-0001 3.00`
 * `./runApp.sh freeze-account admin admin123 ACC-0001`
 * `./runApp.sh unfreeze-account admin admin123 ACC-0001`
+* `./runApp.sh view-interest-rate ACC-0001`
+* `./runApp.sh set-interest-rate admin admin123 ACC-0001 0.03`
 * `./runApp.sh clear-data` (wipes the local database and re-seeds the demo customer `CUST-001`)
 * `./runApp.sh list-accounts CUST-001`
 * `./runApp.sh list-customers admin admin123`
 
-Notes:
->>>>>>> main
+## Notes
 
 * `runApp.sh` compiles the Java sources and runs the app without requiring Gradle to launch it.
 * On the first run, the script downloads `sqlite-jdbc-3.47.2.0.jar` into `lib/`.
@@ -61,21 +48,21 @@ Notes:
 * Gradle is still used for tests: `./gradlew test` on macOS/Linux or `.\gradlew.bat test` in PowerShell on Windows.
 
 ## Initial customer and admin account
+
 ### Customer
-ID: CUST-001
-Name: Demo User
+ID: CUST-001  
+Name: Demo User  
 Password: password
 
 ### Admin
-Username: admin
+Username: admin  
 Password: admin123
-
 
 **Persistence:** Account data is stored in a local SQLite file named `bank.db` in the working directory (created on first run). Separate `./runApp.sh` invocations share this file, so balances and transaction history survive between commands. To use a different path: add `-Dbank.db.file=/absolute/path/to/bank.db` to the Java process before launching the app.
 
 **Seeded admin credentials:** username `admin`, password `admin123`
 
-Implemented features:
+## Implemented features
 
 * User story **#1**: deposit into an existing account
 * User story **#2**: withdraw from an account
@@ -86,21 +73,42 @@ Implemented features:
 * User story **#7**: transfer money from one account to another
 * User story **#8**: bank administrator can collect fees from existing accounts
 * User story **#9**: bank administrator can add an interest payment to an existing account
-* User story **#10** bank administrator can freeze and unfreeze an account to block deposits, withdrawals, and transfers
-* Command-line commands: `create-account`, `deposit`, `withdraw`, `check-balance`, `transaction-history`, `close-account`, `transfer`, `collect-fee`, `add-interest`, `freeze-account`, `unfreeze-account`, `clear-data`
+* User story **#10**: bank administrator can freeze and unfreeze an account to block deposits, withdrawals, and transfers
 * User story **#11**: customer can view the total balance across all of their accounts
-* Command-line commands: `create-account`, `deposit`, `withdraw`, `check-balance`, `total-balance`, `transaction-history`, `close-account`, `transfer`, `collect-fee`, `add-interest`, `clear-data`
 * User story **#12**: customer can list all of their accounts
-* Command-line command: `list-accounts`
 * User story **#13**: bank administrator can view all customers in the bank
-* Command-line command: `list-customers`
 * User story **#14**: customer accounts support password-protected operations
-* Password-protected commands: `create-account`, `withdraw`, `close-account`, `transfer`
 * User story **#15**: customer can view the interest rate for a savings account
-* Command-line command: `view-interest-rate`
 * User story **#16**: bank administrator can manage the interest rate for a savings account
-* Command-line command: `set-interest-rate`
-* SQLite-backed storage persists customers, accounts, transaction history, and admin credentials between CLI runs
+
+## Command-line commands
+
+* `create-account`
+* `deposit`
+* `withdraw`
+* `check-balance`
+* `total-balance`
+* `transaction-history`
+* `transfer`
+* `close-account`
+* `collect-fee`
+* `add-interest`
+* `freeze-account`
+* `unfreeze-account`
+* `list-accounts`
+* `list-customers`
+* `view-interest-rate`
+* `set-interest-rate`
+* `clear-data`
+
+## Password-protected commands
+
+* `create-account`
+* `withdraw`
+* `close-account`
+* `transfer`
+
+SQLite-backed storage persists customers, accounts, transaction history, and admin credentials between CLI runs.
 
 ---
 
@@ -118,15 +126,18 @@ Implemented features:
 
 ---
 
-# Features planned to implement this iteration (iteration 2)
+# Features planned to implement this iteration (Iteration 2)
 
 10. A bank administrator should be able to freeze and unfreeze an account to block deposits and withdrawals. (Daniel)
 11. A bank customer should be able to view the total balance across all of their accounts. (Daniel)
 12. A bank customer should be able to list all of their accounts. (Bobby)
 13. A bank administrator should be able to view all customers in the bank. (Bobby)
+14. A bank customer should be able to set password for their account. (Rosie)
+15. A bank customer should be able to view the interest rate for a savings account. (Nina)
+16. A bank administrator should be able to manage the interest rate for a savings account. (Nina)
+
 ---
 
 # Is there anything that you implemented but doesn't currently work?
 
 No known issues at this time for user story **#5**.
-

--- a/src/main/java/edu/washu/bank/cli/BankCli.java
+++ b/src/main/java/edu/washu/bank/cli/BankCli.java
@@ -106,9 +106,10 @@ public class BankCli {
             System.out.println("5. Transfer");
             System.out.println("6. Transaction History");
             System.out.println("7. Close Account");
+            System.out.println("8. Set Balance Alert Threshold");
             System.out.println("0. Logout");
 
-            int selection = getUserSelection(7);
+            int selection = getUserSelection(8);
             switch (selection) {
                 case 1: viewAccounts(customer); break;
                 case 2: openNewAccount(customer); break;
@@ -117,6 +118,7 @@ public class BankCli {
                 case 5: transfer(customer); break;
                 case 6: transactionHistory(customer); break;
                 case 7: closeAccount(customer); break;
+                case 8: setBalanceAlert(customer); break;
                 case 0:
                     System.out.println("Logged out.");
                     return;
@@ -135,8 +137,8 @@ public class BankCli {
         System.out.println("Your Accounts:");
         for (String accountId : accountIds) {
             bank.findAccount(accountId).ifPresent(a ->
-                System.out.printf("  %-10s  %-10s  Balance: %s%n",
-                        a.getId(), a.getType(), a.getBalance())
+                    System.out.printf("  %-10s  %-10s  Balance: %s%n",
+                            a.getId(), a.getType(), a.getBalance())
             );
         }
     }
@@ -267,6 +269,30 @@ public class BankCli {
             BigDecimal cashOut = accountService.closeAccount(accountId);
             store.saveFullState(bank);
             System.out.println("Account " + accountId + " closed. Cash-out amount: " + cashOut + ".");
+        } catch (RuntimeException ex) {
+            System.out.println("Error: " + ex.getMessage());
+        } catch (SQLException ex) {
+            System.err.println("Database error: " + ex.getMessage());
+        }
+    }
+
+    private void setBalanceAlert(Customer customer) {
+        String accountId = promptAccountId(customer);
+        if (accountId == null) return;
+
+        Account account = bank.findAccount(accountId).orElse(null);
+        if (account == null) return;
+
+        System.out.println("Current alert threshold: " + account.getAlertBalanceThreshold());
+        System.out.print("Enter new alert threshold amount: ");
+        BigDecimal newThreshold = readAmount();
+        if (newThreshold == null) return;
+
+        try {
+            Account updatedAccount = account.withAlertBalanceThreshold(newThreshold);
+            bank.saveAccount(updatedAccount);
+            store.saveFullState(bank);
+            System.out.println("Alert threshold for " + accountId + " updated to " + newThreshold + ".");
         } catch (RuntimeException ex) {
             System.out.println("Error: " + ex.getMessage());
         } catch (SQLException ex) {
@@ -412,13 +438,21 @@ public class BankCli {
             String id = accountIds.get(i);
             int num = i + 1;
             bank.findAccount(id).ifPresent(a ->
-                System.out.printf("  %d. %-10s  %-10s  Balance: %s%n",
-                        num, a.getId(), a.getType(), a.getBalance())
+                    System.out.printf("  %d. %-10s  %-10s  Balance: %s%n",
+                            num, a.getId(), a.getType(), a.getBalance())
             );
         }
-        System.out.print("Enter account ID: ");
+        System.out.print("Enter account ID or number (e.g., 1 or ACC-0001): ");
         String input = scanner.nextLine().trim();
         if (input.isEmpty()) return null;
+
+        try {
+            int index = Integer.parseInt(input) - 1;
+            if (index >= 0 && index < accountIds.size()) {
+                return accountIds.get(index);
+            }
+        } catch (NumberFormatException ignored) {}
+
         if (!customer.getAccountIds().contains(input)) {
             System.out.println("Account not found or does not belong to you.");
             return null;

--- a/src/main/java/edu/washu/bank/model/Account.java
+++ b/src/main/java/edu/washu/bank/model/Account.java
@@ -16,15 +16,15 @@ public class Account {
     private final boolean frozen;
 
     public Account(String id, String customerId, AccountType type, BigDecimal balance) {
-        this(id, customerId, type, balance, BigDecimal.ZERO, false);
+        this(id, customerId, type, balance, BigDecimal.ZERO, false, new BigDecimal("50.00"));
     }
 
     public Account(String id, String customerId, AccountType type, BigDecimal balance, BigDecimal interestRate) {
-        this(id, customerId, type, balance, interestRate, false);
+        this(id, customerId, type, balance, interestRate, false, new BigDecimal("50.00"));
     }
 
     public Account(String id, String customerId, AccountType type, BigDecimal balance, boolean frozen) {
-        this(id, customerId, type, balance, BigDecimal.ZERO, frozen);
+        this(id, customerId, type, balance, BigDecimal.ZERO, frozen, new BigDecimal("50.00"));
     }
 
     public Account(
@@ -33,15 +33,16 @@ public class Account {
             AccountType type,
             BigDecimal balance,
             BigDecimal interestRate,
-            boolean frozen
+            boolean frozen,
+            BigDecimal alertBalanceThreshold
     ) {
         this.id = Objects.requireNonNull(id, "id must not be null");
         this.customerId = Objects.requireNonNull(customerId, "customerId must not be null");
         this.type = Objects.requireNonNull(type, "type must not be null");
         this.balance = Objects.requireNonNull(balance, "balance must not be null");
-        this.alertBalanceThreshold = new BigDecimal("50.00");
         this.interestRate = Objects.requireNonNull(interestRate, "interestRate must not be null");
         this.frozen = frozen;
+        this.alertBalanceThreshold = alertBalanceThreshold != null ? alertBalanceThreshold : new BigDecimal("50.00");
 
         if (interestRate.compareTo(BigDecimal.ZERO) < 0) {
             throw new IllegalArgumentException("Interest rate must not be negative.");
@@ -66,8 +67,8 @@ public class Account {
 
     public BigDecimal getAlertBalanceThreshold() {
         return alertBalanceThreshold;
-    }  
-    
+    }
+
     public BigDecimal getInterestRate() {
         return interestRate;
     }
@@ -96,19 +97,26 @@ public class Account {
         if (newInterestRate == null || newInterestRate.compareTo(BigDecimal.ZERO) < 0) {
             throw new IllegalArgumentException("Interest rate must be 0 or greater.");
         }
-        return new Account(id, customerId, type, balance, newInterestRate, frozen);
+        return new Account(id, customerId, type, balance, newInterestRate, frozen, alertBalanceThreshold);
+    }
+
+    public Account withAlertBalanceThreshold(BigDecimal newThreshold) {
+        if (newThreshold == null || newThreshold.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Alert balance threshold must be 0 or greater.");
+        }
+        return new Account(id, customerId, type, balance, interestRate, frozen, newThreshold);
     }
 
     public Account freeze() {
-        return new Account(id, customerId, type, balance, interestRate, true);
+        return new Account(id, customerId, type, balance, interestRate, true, alertBalanceThreshold);
     }
 
     public Account unfreeze() {
-        return new Account(id, customerId, type, balance, interestRate, false);
+        return new Account(id, customerId, type, balance, interestRate, false, alertBalanceThreshold);
     }
 
     private Account applyDelta(BigDecimal amountDelta) {
-        return new Account(id, customerId, type, balance.add(amountDelta), interestRate, frozen);
+        return new Account(id, customerId, type, balance.add(amountDelta), interestRate, frozen, alertBalanceThreshold);
     }
 
     private void validateDepositAmount(BigDecimal amount) {

--- a/src/main/java/edu/washu/bank/persistence/SqliteBankStore.java
+++ b/src/main/java/edu/washu/bank/persistence/SqliteBankStore.java
@@ -71,6 +71,7 @@ public final class SqliteBankStore {
                             + "balance TEXT NOT NULL,"
                             + "interest_rate TEXT NOT NULL DEFAULT '0',"
                             + "frozen INTEGER NOT NULL DEFAULT 0,"
+                            + "alert_balance_threshold TEXT NOT NULL DEFAULT '50.00',"
                             + "FOREIGN KEY (customer_id) REFERENCES customers(id))"
             );
             st.execute(
@@ -93,6 +94,7 @@ public final class SqliteBankStore {
         ensureAdminsPasswordColumn(connection);
         ensureAccountsInterestRateColumn(connection);
         ensureAccountsFrozenColumn(connection);
+        ensureAccountsAlertThresholdColumn(connection);
     }
 
     /**
@@ -236,6 +238,15 @@ public final class SqliteBankStore {
         }
     }
 
+    private static void ensureAccountsAlertThresholdColumn(Connection c) throws SQLException {
+        if (hasColumn(c, "accounts", "alert_balance_threshold")) {
+            return;
+        }
+        try (Statement st = c.createStatement()) {
+            st.executeUpdate("ALTER TABLE accounts ADD COLUMN alert_balance_threshold TEXT NOT NULL DEFAULT '50.00'");
+        }
+    }
+
     private static boolean hasColumn(Connection c, String tableName, String columnName) throws SQLException {
         try (Statement st = c.createStatement();
              ResultSet rs = st.executeQuery("PRAGMA table_info(" + tableName + ")")) {
@@ -283,7 +294,7 @@ public final class SqliteBankStore {
         }
 
         try (PreparedStatement ps = c.prepareStatement(
-                "SELECT id, customer_id, type, balance, interest_rate, frozen FROM accounts ORDER BY id")) {
+                "SELECT id, customer_id, type, balance, interest_rate, frozen, alert_balance_threshold FROM accounts ORDER BY id")) {
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
                     String id = rs.getString("id");
@@ -292,7 +303,9 @@ public final class SqliteBankStore {
                     BigDecimal balance = new BigDecimal(rs.getString("balance"));
                     BigDecimal interestRate = new BigDecimal(rs.getString("interest_rate"));
                     boolean frozen = rs.getInt("frozen") != 0;
-                    Account account = new Account(id, customerId, type, balance, interestRate, frozen);
+                    BigDecimal alertThreshold = new BigDecimal(rs.getString("alert_balance_threshold"));
+
+                    Account account = new Account(id, customerId, type, balance, interestRate, frozen, alertThreshold);
                     bank.saveAccount(account);
                     bank.findCustomer(customerId).ifPresent(customer -> customer.addAccountId(id));
                 }
@@ -360,7 +373,7 @@ public final class SqliteBankStore {
                     }
                 }
                 try (PreparedStatement ps = c.prepareStatement(
-                        "INSERT INTO accounts (id, customer_id, type, balance, interest_rate, frozen) VALUES (?, ?, ?, ?, ?, ?)")) {
+                        "INSERT INTO accounts (id, customer_id, type, balance, interest_rate, frozen, alert_balance_threshold) VALUES (?, ?, ?, ?, ?, ?, ?)")) {
                     for (Account account : bank.getAccountsSnapshot()) {
                         ps.setString(1, account.getId());
                         ps.setString(2, account.getCustomerId());
@@ -368,6 +381,7 @@ public final class SqliteBankStore {
                         ps.setString(4, account.getBalance().toPlainString());
                         ps.setString(5, account.getInterestRate().toPlainString());
                         ps.setInt(6, account.isFrozen() ? 1 : 0);
+                        ps.setString(7, account.getAlertBalanceThreshold().toPlainString());
                         ps.executeUpdate();
                     }
                 }


### PR DESCRIPTION
Description
This PR addresses Issue #44: Set Balance Alerts by Customers.

Changes Made:
Account.java:
* Added an `alertBalanceThreshold` property (defaulting to 50.00) and a `getAlertBalanceThreshold()` getter.
* Added a `withAlertBalanceThreshold()` method to allow updating the threshold while maintaining immutability.
* Added logic in the `withdraw()` method to print an alert message (`Alert: Account balance is below the alert threshold.`) when the balance drops below the customized threshold.

BankCli.java:
* Added a new option `8. Set Balance Alert Threshold` to the Customer Menu.
* Implemented the `setBalanceAlert()` method to handle threshold updates interactively.
* Improved the `promptAccountId()` helper method to accept either the full Account ID (e.g., `ACC-0001`) or its corresponding list index (e.g., `1`), enhancing overall user experience.

SqliteBankStore.java:
* Updated the database schema management by adding the `alert_balance_threshold` column to the `accounts` table so that threshold preferences are tracked correctly across multiple CLI runs.

How to Test:
1. Run the application: `./runApp.sh` or `.\gradlew.bat run --console=plain`
2. Log in as a customer (e.g., `CUST-001` with password `password`).
3. Select option `8` to set a new balance alert threshold for an account (e.g., set it to `10.00`).
4. Select option `4` to withdraw an amount that causes the remaining balance to drop below the newly set threshold.
5. Verify that the warning message is printed to the console.